### PR TITLE
Version that reproduces improved-action parallel pfaffian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+SUSY_LATTICE
 .DS_Store
 *.d
 *.o

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ It is very easy to perform the installation and execution of `SUSY_LATTICE`.  Be
 1. Download and unpack the code.
 2. Change the directory to `SUSY_LATTICE`.
 3. Edit utilities.h to set the number of supercharges by (un)defining Q16, and lattice lengths LX, LY, LZ and T.  Note: setting e.g. LX=1 allows study of corresponding dimensionally reduced model.  Number of colors is given by NCOLOR.  The compilation parameter FULLMATRIX allows one to compute the Pfaffian and fermion eigenvalues using full matrix code (for small lattices).
-4. Compile the code: `g++ -O *.cpp -o SUSY_LATTICE -llapack -lblas`
+4. Compile the code: `g++ -O *.cpp -o SUSY\_LATTICE -llapack -lblas`
 Setting the parameter SCALAREIG=0 in utiliities.h allows compilation without the LAPACK and BLAS libraries at the expense of having no measurements of the (scalar) eigenvalues.
+Setting `ulimit -s unlimited` may be required when running with `-DFULLMATRIX`
 5. Modify the input parameters located in file `parameters`
 6. Type `./SUSY_LATTICE &> log &` to run the code.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ It is very easy to perform the installation and execution of `SUSY_LATTICE`.  Be
 1. Download and unpack the code.
 2. Change the directory to `SUSY_LATTICE`.
 3. Edit utilities.h to set the number of supercharges by (un)defining Q16, and lattice lengths LX, LY, LZ and T.  Note: setting e.g. LX=1 allows study of corresponding dimensionally reduced model.  Number of colors is given by NCOLOR.  The compilation parameter FULLMATRIX allows one to compute the Pfaffian and fermion eigenvalues using full matrix code (for small lattices).
-4. Compile the code:
-```
-g++ -O *.cpp -o SUSY_LATTICE -llapack -lblas
-```
+4. Compile the code: `g++ -O *.cpp -o SUSY_LATTICE -llapack -lblas`
 Setting the parameter SCALAREIG=0 in utiliities.h allows compilation without the LAPACK and BLAS libraries at the expense of having no measurements of the (scalar) eigenvalues.
 5. Modify the input parameters located in file `parameters`
 6. Type `./SUSY_LATTICE &> log &` to run the code.

--- a/action.cpp
+++ b/action.cpp
@@ -1,102 +1,93 @@
 #include "action.h"
 
-double action(const Gauge_Field &U, const Twist_Fermion F){
-Lattice_Vector x,e_mu,e_nu;
-Gauge_Field Udag;
-Complex dum,d,trace;
-Umatrix p,dummy;
-USite_Field DmuUmu;
-UPlaq_Field P;
-double act_s=0.0, act_F=0.0;
-int mu,nu,site; 
-Twist_Fermion sol[DEGREE],psol[DEGREE];
-Umatrix Fmunu;
+double action(const Gauge_Field &U, const Twist_Fermion F) {
+  Lattice_Vector x,e_mu,e_nu;
+  Gauge_Field Udag;
+  Complex dum,d,trace;
+  Umatrix p,dummy;
+  USite_Field DmuUmu;
+  UPlaq_Field P;
+  double act_s = 0.0, act_F = 0.0;
+  int mu,nu,site;
+  Twist_Fermion sol[DEGREE],psol[DEGREE];
+  Umatrix Fmunu;
+
+  Udag = Adj(U);
 
 
-Udag=Adj(U);
+  P = Plaq(U);
+  site = 0;
+  while(loop_over_lattice(x,site)) {
+    dum = Complex();
+    for (mu = 0;mu<NUMLINK;mu++) {
+      for (nu = 0;nu<NUMLINK;nu++) {
+        if (mu == nu) continue;
+        dum = dum+(det(P.get(x,mu,nu))-Complex(1.0,0.0));
+      }
+    }
+    DmuUmu.set(x,G*dum*Umatrix(1));
+  }
+
+  // usual piece
+  site = 0;
+  while(loop_over_lattice(x,site)) {
+    for (mu = 0;mu<NUMLINK;mu++) {
+      e_mu = Lattice_Vector(mu);
+      DmuUmu.set(x,DmuUmu.get(x)+U.get(x,mu)*Udag.get(x,mu)-
+          Udag.get(x-e_mu,mu)*U.get(x-e_mu,mu));}
+
+      act_s = act_s+0.5*C2*Tr(DmuUmu.get(x)*DmuUmu.get(x)).real();
+  }
+
+  // Konishi mass term - single trace operator - 'eig'  //
+  site = 0;
+  dum = Complex();
+  while(loop_over_lattice(x,site)) {
+    for (mu = 0;mu<NUMLINK;mu++) {
+      dummy = U.get(x,mu)*Udag.get(x,mu)-Umatrix(1);
+      dum = dum+Tr(dummy*dummy);
+    }}
+
+  act_s = act_s+(BMASS*BMASS)*dum.real();
+
+  // Below : Double trace mass term - "trace" //
+  /* site = 0;
+     while(loop_over_lattice(x,site)) {
+     for (mu = 0;mu<NUMLINK;mu++) {
+     dum =(1.0/NCOLOR)*Tr(Udag.get(x,mu)*U.get(x,mu)).real()-1.0;
+     act_s = act_s+(BMASS*BMASS)*dum*dum;
+     }}  */
+
+  site = 0;
+  while(loop_over_lattice(x,site)) {
+    for (mu = 0;mu<NUMLINK;mu++) {
+      e_mu = Lattice_Vector(mu);
+      for (nu = mu+1;nu<NUMLINK;nu++) {
+        e_nu = Lattice_Vector(nu);
+        Fmunu = U.get(x,mu)*U.get(x+e_mu,nu)-U.get(x,nu)*U.get(x+e_nu,mu);
+        act_s = act_s+2.0*Tr(Fmunu*Adj(Fmunu)).real();
+
+      }
+    }
+  }
 
 
-P=Plaq(U);
-site=0;
-while(loop_over_lattice(x,site)){
-dum=Complex();
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=0;nu<NUMLINK;nu++){
-if(mu==nu) continue;
-dum=dum+(det(P.get(x,mu,nu))-Complex(1.0,0.0));}}
-DmuUmu.set(x,G*dum*Umatrix(1));
-}
-
-// usual piece
-site=0;
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-DmuUmu.set(x,DmuUmu.get(x)+U.get(x,mu)*Udag.get(x,mu)-
-                           Udag.get(x-e_mu,mu)*U.get(x-e_mu,mu));}
-    
-act_s=act_s+0.5*C2*Tr(DmuUmu.get(x)*DmuUmu.get(x)).real();
-}
+  act_s = KAPPA*act_s;
 
 
-// Konishi mass term - single trace operator - 'eig'  // 
+  // Now, the fermions //
+
+  // Pseudofermion contribution
 
 
-site=0;
-dum=Complex();
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){        
-dummy=U.get(x,mu)*Udag.get(x,mu)-Umatrix(1);
-dum=dum+Tr(dummy*dummy);
-}}
+  if (FERMIONS) {
+    act_F = ampdeg*(Cjg(F)*F).real();
 
-act_s=act_s+(BMASS*BMASS)*dum.real();
+    MCG_solver(U,F,shift,sol,psol);
 
+    for (int n = 0;n<DEGREE;n++) {
+      act_F = act_F+amp[n]*(Cjg(F)*sol[n]).real();}
+  }
 
-// Below : Double trace mass term - "trace" // 
-
-/* site=0;
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){
-dum=(1.0/NCOLOR)*Tr(Udag.get(x,mu)*U.get(x,mu)).real()-1.0;
-act_s=act_s+(BMASS*BMASS)*dum*dum;
-}}  */ 
-
-
-
-site=0;
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-for(nu=mu+1;nu<NUMLINK;nu++){
-e_nu=Lattice_Vector(nu);
-Fmunu=U.get(x,mu)*U.get(x+e_mu,nu)-U.get(x,nu)*U.get(x+e_nu,mu);
-act_s=act_s+2.0*Tr(Fmunu*Adj(Fmunu)).real();
-
-}
-}
-}
-
-
-act_s=KAPPA*act_s;
-
-
-// Now, the fermions // 
-
-// Pseudofermion contribution
-
-
-if(FERMIONS){
-
-act_F=ampdeg*(Cjg(F)*F).real();
-
-MCG_solver(U,F,shift,sol,psol);
-
-for(int n=0;n<DEGREE;n++){
-act_F=act_F+amp[n]*(Cjg(F)*sol[n]).real();}
-}
-
-
-
-return(act_s+act_F);
+  return (act_s + act_F);
 }

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -210,11 +210,8 @@ void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
     }
   }
 
-
   // SIMON: susy det term modification
-
   if (GO) {
-
     P = Plaq(U);
     sites = 0;
     while(loop_over_lattice(x, sites)) {
@@ -286,7 +283,6 @@ void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
 
 
   // psi_mu Dminus chi
-
   sites = 0;
   while(loop_over_lattice(x, sites)) {
     for (nu = 0;nu<NUMLINK;nu++) {
@@ -330,8 +326,6 @@ void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
   }
 
   // chi Dplus psi_mu
-
-
   sites = 0;
   while(loop_over_lattice(x, sites)) {
     for (mu = 0;mu<NUMLINK;mu++) {
@@ -374,7 +368,6 @@ void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
   }
 
   // Q-closed pieces
-
   if (NUMLINK == 5) {
     sites = 0;
     while(loop_over_lattice(x, sites)) {
@@ -512,13 +505,10 @@ void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
     first_time = 0;}
 
   return;
-
 }
 
 // simple bubble sort for each row
-
-void mysort(Complex d[], int key[], int n)
-{
+void mysort(Complex d[], int key[], int n) {
   int i, newn;
   Complex c;
   int p;
@@ -640,10 +630,8 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
 
     }
   }
+
   // psi_mu dbarT eta
-
-
-
   sites = 0;
   while(loop_over_lattice(x, sites)) {
     for (a = 0;a<NUMGEN;a++) {
@@ -658,10 +646,7 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
           M[i][j2]= M[i][j2]-Tr(Lambda[a]*Udag.get(x, mu)*Lambda[b]);
         }}}}
 
-
   // chi_{munu} dmu psi_nu
-
-
   sites = 0;
   while(loop_over_lattice(x, sites)) {
 
@@ -688,9 +673,8 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
             M[i][j2]= M[i][j2]+Tr(Lambda[b]*U.get(x+e_mu, nu)*Lambda[a]);
 
           }}}}}
+
   // psi_nu dmu chi_{munu}
-
-
   sites = 0;
   while(loop_over_lattice(x, sites)) {
 
@@ -721,9 +705,7 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
       }
     }}
 
-
   // Q-closed term
-
   if (NUMLINK == 5) {
     sites = 0;
     while(loop_over_lattice(x, sites)) {
@@ -800,9 +782,7 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
 
 
   // SIMON: susy det term modification
-
   if (NUMGEN ==(NCOLOR*NCOLOR)) {
-
     P = Plaq(U);
     sites = 0;
     while(loop_over_lattice(x, sites)) {
@@ -847,7 +827,6 @@ void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
           M[j1][j2] << "\t" << M[j2][j1] << "\n" << flush;}
     }
   }
-
 
   return;
 }

--- a/matrix.cpp
+++ b/matrix.cpp
@@ -2,516 +2,516 @@
 #include "matrix.h"
 #include "eig.h"
 
-int lat_pack(const Lattice_Vector &x){
-int i,site=0;
+int lat_pack(const Lattice_Vector &x) {
+  int i, site = 0;
 
-for(i=0;i<D;i++){
-site=site+Lattice_Map[i]*x.get(i);
+  for (i = 0;i<D;i++) {
+    site = site+Lattice_Map[i]*x.get(i);
+  }
+
+  return(site);
 }
 
-return(site);
+void lat_unpack(const int n, Lattice_Vector &x) {
+  int current, i;
+
+  current = n;
+  for (i = D-1;i>= 0;i--) {
+    x.set(i, current/Lattice_Map[i]);
+    current = current-Lattice_Map[i]*x.get(i);
+  }
+
+  return;
 }
 
-void lat_unpack(const int n, Lattice_Vector &x){
-int current,i;
+int pack(const int flavor, const Lattice_Vector &x, const int color) {
+  int i;
+  i =(SITES*NUMGEN)*flavor+NUMGEN*lat_pack(x)+color;
 
-current=n;
-for(i=D-1;i>=0;i--){
-x.set(i,current/Lattice_Map[i]);
-current=current-Lattice_Map[i]*x.get(i);
+  return(i);
 }
 
-return;
-}
-
-int pack(const int flavor, const Lattice_Vector &x, const int color){
-int i;
-i=(SITES*NUMGEN)*flavor+NUMGEN*lat_pack(x)+color;
-
-return(i);
-}
-
-void unpack(const int i, int &flavor, Lattice_Vector &x, int &color){
-int tmp;
-flavor=i/(SITES*NUMGEN);
-tmp=i-flavor*(SITES*NUMGEN);
-lat_unpack(tmp/NUMGEN,x);
-color=tmp-(tmp/NUMGEN)*NUMGEN;
-return;
-}
-
-
-int flavor(const int mu, const int nu){
-int dum;
-
-if(mu==0){
-dum=nu;}
-if(mu==1){
-dum=5+nu-2;}
-if(mu==2){
-dum=8+nu-3;}
-if(mu==3){
-dum=10;}
-return(dum);
+void unpack(const int i, int &flavor, Lattice_Vector &x, int &color) {
+  int tmp;
+  flavor = i/(SITES*NUMGEN);
+  tmp = i-flavor*(SITES*NUMGEN);
+  lat_unpack(tmp/NUMGEN, x);
+  color = tmp-(tmp/NUMGEN)*NUMGEN;
+  return;
 }
 
 
-int find_index(const int i, const int j, int col[LEN], int row[LEN+1]){
-int k;
+int flavor(const int mu, const int nu) {
+  int dum;
 
-//cout << "i and j are " << i << "\t" << j << "\n" << flush;
-
-for(k=row[i];k<row[i]+num_in_row[i];k++){
-if(col[k]==j) {
-//cout << "found col " << j << "already with index " << k << "\n" << flush;
-return(k);}
-}
-// new col
-// check that lies in allowed range
-k=row[i]+num_in_row[i];
-if(k<row[i+1])
-{
-//cout << "new nonzero at " << k << "\n" << flush;
-num_in_row[i]++;
-//cout << "number in row " << i << " is " << num_in_row[i] << "\n" << flush;
-return(k);}
-else{
-cout << "error building matrix: num_in_row exceeds nonzeroes \n";exit(1);}
-
-
+  if (mu == 0) {
+    dum = nu;}
+  if (mu == 1) {
+    dum = 5+nu-2;}
+  if (mu == 2) {
+    dum = 8+nu-3;}
+  if (mu == 3) {
+    dum = 10;}
+  return(dum);
 }
 
 
-void build_vector(const Twist_Fermion &t, Complex v[LEN]){
-int sites,mu,nu,index,a,num_chis;
-Lattice_Vector x;
+int find_index(const int i, const int j, int col[LEN], int row[LEN+1]) {
+  int k;
 
-num_chis=(NUMLINK*(NUMLINK-1))/2;
+  //cout << "i and j are " << i << "\t" << j << "\n" << flush;
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMGEN;a++){
-
-index=pack(0,x,a);
-v[index]=t.getS().get(x).get(a);
-
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=mu+1;nu<NUMLINK;nu++){
-index=pack(flavor(mu,nu),x,a);
-v[index]=t.getC().get(x,mu,nu).get(a);}}
-
-for(mu=0;mu<NUMLINK;mu++){
-index=pack((num_chis+1+mu),x,a);
-v[index]=t.getL().get(x,mu).get(a);}
-}
-}
-return;
-}
-
-Twist_Fermion extract_vector(Complex v[LEN]){
-int sites,mu,nu,index,a,num_chis;
-Lattice_Vector x;
-Site_Field s=Site_Field();
-Link_Field l=Link_Field();
-Plaq_Field p=Plaq_Field();
-Afield atmp;
-Twist_Fermion t;
-
-num_chis=(NUMLINK*(NUMLINK-1))/2;
-sites=0;
-while(loop_over_lattice(x,sites)){
-
-for(a=0;a<NUMGEN;a++){
-index=pack(0,x,a);
-atmp.set(a,v[index]);}
-
-s.set(x,atmp);
-
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=mu+1;nu<NUMLINK;nu++){
-
-for(a=0;a<NUMGEN;a++){
-index=pack(flavor(mu,nu),x,a);
-atmp.set(a,v[index]);}
-
-p.set(x,mu,nu,atmp);
-p.set(x,nu,mu,-1.0*atmp);
-}}
-
-for(mu=0;mu<NUMLINK;mu++){
-for(a=0;a<NUMGEN;a++){
-index=pack(mu+num_chis+1,x,a);
-atmp.set(a,v[index]);}
-
-l.set(x,mu,atmp);}
-
-}
-
-t.setS(s);
-t.setL(l);
-t.setC(p);
-
-return(t);
+  for (k = row[i];k<row[i]+num_in_row[i];k++) {
+    if (col[k]== j) {
+      //cout << "found col " << j << "already with index " << k << "\n" << flush;
+      return(k);}
+  }
+  // new col
+  // check that lies in allowed range
+  k = row[i]+num_in_row[i];
+  if (k<row[i+1]) {
+    //cout << "new nonzero at " << k << "\n" << flush;
+    num_in_row[i]++;
+    //cout << "number in row " << i << " is " << num_in_row[i] << "\n" << flush;
+    return(k);
+  }
+  else {
+    cout << "error building matrix: num_in_row exceeds nonzeroes \n";
+    exit(1);
+  }
 }
 
 
+void build_vector(const Twist_Fermion &t, Complex v[LEN]) {
+  int sites, mu, nu, index, a, num_chis;
+  Lattice_Vector x;
 
-void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U, 
-Complex m[],int col[],int row[]){
-int sites,mu,nu,a,b,c,ix,i,j1,j2,d,e,l,k;
-Lattice_Vector x,e_mu,e_nu,e_a,e_b,e_c;
-static int first_time=1;
-static ofstream f_op;
-Complex W,Z;
-UPlaq_Field P;
+  num_chis =(NUMLINK*(NUMLINK-1))/2;
 
-//if(first_time){
-//	f_op.open("sparse_fermion_op");
-//	if(f_op.bad()){ 
-//	cout << "failed to open fermion op file\n" << flush ;}
-//}
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (a = 0;a<NUMGEN;a++) {
 
-int num_chis=(NUMLINK*(NUMLINK-1))/2;
+      index = pack(0, x, a);
+      v[index]= t.getS().get(x).get(a);
 
-for(i=0;i<LEN;i++){
-row[i]=NONZEROES*i;
-num_in_row[i]=0;
-}
-row[LEN]=NONZEROES*LEN;
+      for (mu = 0;mu<NUMLINK;mu++) {
+        for (nu = mu+1;nu<NUMLINK;nu++) {
+          index = pack(flavor(mu, nu), x, a);
+          v[index]= t.getC().get(x, mu, nu).get(a);}}
 
-// set off initially
-for(i=0;i<(LEN*NONZEROES);i++){
-col[i]=-1;
-m[i]=Complex();
+      for (mu = 0;mu<NUMLINK;mu++) {
+        index = pack((num_chis+1+mu), x, a);
+        v[index]= t.getL().get(x, mu).get(a);}
+    }
+  }
+  return;
 }
 
-// eta Dminus psi_mu
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMGEN;a++){
-i=pack(0,x,a);
+Twist_Fermion extract_vector(Complex v[LEN]) {
+  int sites, mu, nu, index, a, num_chis;
+  Lattice_Vector x;
+  Site_Field s = Site_Field();
+  Link_Field l = Link_Field();
+  Plaq_Field p = Plaq_Field();
+  Afield atmp;
+  Twist_Fermion t;
 
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-for(b=0;b<NUMGEN;b++){
-j1=pack(mu+num_chis+1,x,b);
-j2=pack(mu+num_chis+1,x-e_mu,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+
-0.5*conjug(V.get(x,mu).get(a,b));
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-
-0.5*conjug(V.get(x-e_mu,mu).get(b,a))*BC(x,-e_mu);
-col[ix]=j2;
- 
-}
-}
-}
-}
+  num_chis =(NUMLINK*(NUMLINK-1))/2;
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
 
+    for (a = 0;a<NUMGEN;a++) {
+      index = pack(0, x, a);
+      atmp.set(a, v[index]);}
 
-// SIMON: susy det term modification
+    s.set(x, atmp);
 
-if(GO){
+    for (mu = 0;mu<NUMLINK;mu++) {
+      for (nu = mu+1;nu<NUMLINK;nu++) {
 
-P=Plaq(U);
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=0;nu<NUMLINK;nu++){
-if(mu==nu) continue;
-e_mu=Lattice_Vector(mu);
+        for (a = 0;a<NUMGEN;a++) {
+          index = pack(flavor(mu, nu), x, a);
+          atmp.set(a, v[index]);}
 
-W=det(P.get(x,mu,nu))-Complex(1.0,0.0);
+        p.set(x, mu, nu, atmp);
+        p.set(x, nu, mu,-1.0*atmp);
+      }}
 
-Z=sqrt(1.0*NCOLOR)*Complex(0.0,1.0)*(Complex(1.0,0.0)+W);
+    for (mu = 0;mu<NUMLINK;mu++) {
+      for (a = 0;a<NUMGEN;a++) {
+        index = pack(mu+num_chis+1, x, a);
+        atmp.set(a, v[index]);}
 
-i=pack(0,x,NUMGEN-1);
+      l.set(x, mu, atmp);}
 
-for(b=0;b<NUMGEN;b++){
-j1=pack(num_chis+1+mu,x,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+G*0.5*Z*Tr(inverse(U.get(x,mu))*Lambda[b]);
-col[ix]=j1;
+  }
 
-j1=pack(num_chis+1+nu,x+e_mu,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+G*0.5*Z*Tr(inverse(U.get(x+e_mu,nu))*Lambda[b])*BC(x,e_mu);
-col[ix]=j1;
-}
+  t.setS(s);
+  t.setL(l);
+  t.setC(p);
 
-j1=pack(0,x,NUMGEN-1);
-
-for(b=0;b<NUMGEN;b++){
-i=pack(num_chis+1+mu,x,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]-G*0.5*Z*Tr(inverse(U.get(x,mu))*Lambda[b]);
-col[ix]=j1;
-
-i=pack(num_chis+1+nu,x+e_mu,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]-G*0.5*Z*Tr(inverse(U.get(x+e_mu,nu))*Lambda[b])*BC(x,e_mu);
-col[ix]=j1;
-}
-
-}}}}
-
-// psi_mu Dplus eta
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-
-for(a=0;a<NUMGEN;a++){
-i=pack(mu+num_chis+1,x,a);
-
-for(b=0;b<NUMGEN;b++){
-j1=pack(0,x+e_mu,b);
-j2=pack(0,x,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+
-0.5*conjug(V.get(x,mu).get(a,b))*BC(x,e_mu);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-
-0.5*conjug(V.get(x,mu).get(b,a));
-col[ix]=j2;
-}
-
-}
-}
+  return(t);
 }
 
 
-// psi_mu Dminus chi
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(nu=0;nu<NUMLINK;nu++){
-e_nu=Lattice_Vector(nu);
+void build_sparse_matrix(const Adjoint_Links &V, const Gauge_Field &U,
+    Complex m[], int col[], int row[]) {
+  int sites, mu, nu, a, b, c, ix, i, j1, j2, d, e, l, k;
+  Lattice_Vector x, e_mu, e_nu, e_a, e_b, e_c;
+  static int first_time = 1;
+  static ofstream f_op;
+  Complex W, Z;
+  UPlaq_Field P;
 
-for(a=0;a<NUMGEN;a++){
+  //if (first_time) {
+  //  f_op.open("sparse_fermion_op");
+  //  if (f_op.bad()) {
+  //  cout << "failed to open fermion op file\n" << flush ;}
+  //}
 
-for(mu=nu+1;mu<NUMLINK;mu++){
+  int num_chis =(NUMLINK*(NUMLINK-1))/2;
 
-e_mu=Lattice_Vector(mu);
+  for (i = 0;i<LEN;i++) {
+    row[i]= NONZEROES*i;
+    num_in_row[i]= 0;
+  }
+  row[LEN]= NONZEROES*LEN;
 
-for(b=0;b<NUMGEN;b++){
-i=pack(nu+num_chis+1,x,a);
-j1=pack(flavor(nu,mu),x,b);
-j2=pack(flavor(nu,mu),x-e_mu,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]-
-V.get(x+e_nu,mu).get(a,b);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]+
-V.get(x-e_mu,mu).get(b,a)*BC(x,-e_mu);
-col[ix]=j2;
+  // set off initially
+  for (i = 0;i<(LEN*NONZEROES);i++) {
+    col[i]=-1;
+    m[i]= Complex();
+  }
 
-i=pack(mu+num_chis+1,x,a);
-j1=pack(flavor(nu,mu),x,b);
-j2=pack(flavor(nu,mu),x-e_nu,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+
-V.get(x+e_mu,nu).get(a,b);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-
-V.get(x-e_nu,nu).get(b,a)*BC(x,-e_nu);
-col[ix]=j2;
-}
-}
-}
+  // eta Dminus psi_mu
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (a = 0;a<NUMGEN;a++) {
+      i = pack(0, x, a);
 
-}
-}
+      for (mu = 0;mu<NUMLINK;mu++) {
+        e_mu = Lattice_Vector(mu);
+        for (b = 0;b<NUMGEN;b++) {
+          j1 = pack(mu+num_chis+1, x, b);
+          j2 = pack(mu+num_chis+1, x-e_mu, b);
+          ix = find_index(i, j1, col, row);
+          m[ix]= m[ix]+
+            0.5*conjug(V.get(x, mu).get(a, b));
+          col[ix]= j1;
+          ix = find_index(i, j2, col, row);
+          m[ix]= m[ix]-
+            0.5*conjug(V.get(x-e_mu, mu).get(b, a))*BC(x,-e_mu);
+          col[ix]= j2;
 
-// chi Dplus psi_mu
-
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=mu+1;nu<NUMLINK;nu++){
-
-e_mu=Lattice_Vector(mu);
-e_nu=Lattice_Vector(nu);
-
-for(a=0;a<NUMGEN;a++){
-i=pack(flavor(mu,nu),x,a);
-
-for(b=0;b<NUMGEN;b++){
-j1=pack(nu+num_chis+1,x+e_mu,b);
-j2=pack(nu+num_chis+1,x,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+
-V.get(x,mu).get(a,b)*BC(x,e_mu);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-
-V.get(x+e_nu,mu).get(b,a);
-col[ix]=j2;
-
-j1=pack(mu+num_chis+1,x+e_nu,b);
-j2=pack(mu+num_chis+1,x,b);
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]-
-V.get(x,nu).get(a,b)*BC(x,e_nu);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]+
-V.get(x+e_mu,nu).get(b,a);
-col[ix]=j2;
-
-}
-}
-
-}
-}
-}
-
-// Q-closed pieces
-
-if(NUMLINK==5){
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(d=0;d<NUMLINK;d++){
-for(e=d+1;e<NUMLINK;e++){
-
-for(l=0;l<NUMGEN;l++){
-i=pack(flavor(d,e),x,l);
-
-for(c=0;c<NUMLINK;c++){
-if((c==d)||(c==e)) continue;
-
-e_c=Lattice_Vector(c);
-
-for(a=0;a<NUMLINK;a++){
-e_a=Lattice_Vector(a);
-if((a==c)||(a==d)||(a==e)) continue;
-for(b=a+1;b<NUMLINK;b++){
-e_b=Lattice_Vector(b);
-if((b==c)||(b==d)||(b==e)) continue;
-
-for(k=0;k<NUMGEN;k++){
-
-j1=pack(flavor(a,b),x-e_a-e_b,k);
-j2=pack(flavor(a,b),x-e_a-e_b-e_c,k);
-
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+0.5*perm[d][e][c][a][b]*
-conjug(V.get(x-e_a-e_b-e_c,c).get(l,k))*BC(x,-e_a,-e_b);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-0.5*perm[d][e][c][a][b]*
-conjug(V.get(x-e_c,c).get(k,l))*BC(x,-e_a,-e_b,-e_c);
-col[ix]=j2;
-}}
-}
-
-}}}}}
+        }
+      }
+    }
+  }
 
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMLINK;a++){
-e_a=Lattice_Vector(a);
-for(b=a+1;b<NUMLINK;b++){
-e_b=Lattice_Vector(b);
+  // SIMON: susy det term modification
 
-for(l=0;l<NUMGEN;l++){
-i=pack(flavor(a,b),x,l);
+  if (GO) {
 
-for(c=0;c<NUMLINK;c++){
-if((c==a)||(c==b)) continue;
+    P = Plaq(U);
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (mu = 0;mu<NUMLINK;mu++) {
+        for (nu = 0;nu<NUMLINK;nu++) {
+          if (mu == nu) continue;
+          e_mu = Lattice_Vector(mu);
 
-e_c=Lattice_Vector(c);
+          W = det(P.get(x, mu, nu))-Complex(1.0, 0.0);
 
-for(d=0;d<NUMLINK;d++){
+          Z = sqrt(1.0*NCOLOR)*Complex(0.0, 1.0)*(Complex(1.0, 0.0)+W);
 
-if((d==c)||(d==a)||(d==b)) continue;
-for(e=d+1;e<NUMLINK;e++){
+          i = pack(0, x, NUMGEN-1);
 
-if((e==c)||(e==a)||(e==b)) continue;
-for(k=0;k<NUMGEN;k++){
+          for (b = 0;b<NUMGEN;b++) {
+            j1 = pack(num_chis+1+mu, x, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]+G*0.5*Z*Tr(inverse(U.get(x, mu))*Lambda[b]);
+            col[ix]= j1;
 
-j1=pack(flavor(d,e),x+e_a+e_b+e_c,k);
-j2=pack(flavor(d,e),x+e_a+e_b,k);
+            j1 = pack(num_chis+1+nu, x+e_mu, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]+G*0.5*Z*Tr(inverse(U.get(x+e_mu, nu))*Lambda[b])*BC(x, e_mu);
+            col[ix]= j1;
+          }
 
-ix=find_index(i,j1,col,row);
-m[ix]=m[ix]+0.5*perm[a][b][c][d][e]*
-conjug(V.get(x+e_a+e_b,c).get(l,k))*BC(x,e_a,e_b,e_c);
-col[ix]=j1;
-ix=find_index(i,j2,col,row);
-m[ix]=m[ix]-0.5*perm[a][b][c][d][e]*
-conjug(V.get(x-e_c,c).get(k,l))*BC(x,e_a,e_b);
-col[ix]=j2;
+          j1 = pack(0, x, NUMGEN-1);
 
-}}
-}
+          for (b = 0;b<NUMGEN;b++) {
+            i = pack(num_chis+1+mu, x, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]-G*0.5*Z*Tr(inverse(U.get(x, mu))*Lambda[b]);
+            col[ix]= j1;
 
-}}}}}
-}
+            i = pack(num_chis+1+nu, x+e_mu, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]-G*0.5*Z*Tr(inverse(U.get(x+e_mu, nu))*Lambda[b])*BC(x, e_mu);
+            col[ix]= j1;
+          }
 
-// remove blanks ...
-int n2[LEN],c2[LEN*NONZEROES];
-Complex m2[LEN*NONZEROES];
+        }}}}
 
-k=0; 
-l=0;
-for(i=0;i<LEN;i++){
-l+=num_in_row[i];
-n2[i]=0;
-for(int j=row[i];j<row[i+1];j++){
-if(col[j]!=(-1)){
-m2[k]=m[j];
-c2[k]=col[j];
-k++;
-n2[i]++;}
-}
-}
+  // psi_mu Dplus eta
 
-//cout << "Total number of nonzeroes " << k << "\t" << l << endl;
-TOTALNONZEROES=k;
-row[0]=0;
-for(i=0;i<LEN;i++){
-if(n2[i]!=num_in_row[i]){cout << "uh oh ..." << endl;}
-row[i+1]=row[i]+n2[i];
-}
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (mu = 0;mu<NUMLINK;mu++) {
+      e_mu = Lattice_Vector(mu);
 
-for(i=0;i<LEN;i++){
-for(int j=row[i];j<row[i+1];j++){
-if(c2[j]==(-1)){cout << "oops i= " << i << "\t" << "j is " << j << endl;
-cout << "row[i] is " << row[i] << "\t" << "row[i+1] is" << row[i+1] << endl;}
-col[j]=c2[j];
-m[j]=m2[j];
-}}
+      for (a = 0;a<NUMGEN;a++) {
+        i = pack(mu+num_chis+1, x, a);
+
+        for (b = 0;b<NUMGEN;b++) {
+          j1 = pack(0, x+e_mu, b);
+          j2 = pack(0, x, b);
+          ix = find_index(i, j1, col, row);
+          m[ix]= m[ix]+
+            0.5*conjug(V.get(x, mu).get(a, b))*BC(x, e_mu);
+          col[ix]= j1;
+          ix = find_index(i, j2, col, row);
+          m[ix]= m[ix]-
+            0.5*conjug(V.get(x, mu).get(b, a));
+          col[ix]= j2;
+        }
+
+      }
+    }
+  }
 
 
+  // psi_mu Dminus chi
 
-// order by columns within a row block
-col_order(m,col,row);
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (nu = 0;nu<NUMLINK;nu++) {
+      e_nu = Lattice_Vector(nu);
 
-//for(i=0;i<=LEN;i++){
-//f_op << row[i] << endl;
-//}
-//for(i=0;i<(NONZEROES*LEN);i++){
-//f_op << col[i] << endl;
-//}
-//for(i=0;i<(NONZEROES*LEN);i++){
-//f_op << m[i] << endl;
-//}
-//f_op.close();
+      for (a = 0;a<NUMGEN;a++) {
 
-if(first_time){
-cout << "Maximum number nonzeroes in row " << num_in_row[3] << "\n" << flush;
-cout << "Total number of nonzeroes " << TOTALNONZEROES << endl;
-first_time=0;}
+        for (mu = nu+1;mu<NUMLINK;mu++) {
 
-return;
+          e_mu = Lattice_Vector(mu);
+
+          for (b = 0;b<NUMGEN;b++) {
+            i = pack(nu+num_chis+1, x, a);
+            j1 = pack(flavor(nu, mu), x, b);
+            j2 = pack(flavor(nu, mu), x-e_mu, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]-
+              V.get(x+e_nu, mu).get(a, b);
+            col[ix]= j1;
+            ix = find_index(i, j2, col, row);
+            m[ix]= m[ix]+
+              V.get(x-e_mu, mu).get(b, a)*BC(x,-e_mu);
+            col[ix]= j2;
+
+            i = pack(mu+num_chis+1, x, a);
+            j1 = pack(flavor(nu, mu), x, b);
+            j2 = pack(flavor(nu, mu), x-e_nu, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]+
+              V.get(x+e_mu, nu).get(a, b);
+            col[ix]= j1;
+            ix = find_index(i, j2, col, row);
+            m[ix]= m[ix]-
+              V.get(x-e_nu, nu).get(b, a)*BC(x,-e_nu);
+            col[ix]= j2;
+          }
+        }
+      }
+
+    }
+  }
+
+  // chi Dplus psi_mu
+
+
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (mu = 0;mu<NUMLINK;mu++) {
+      for (nu = mu+1;nu<NUMLINK;nu++) {
+
+        e_mu = Lattice_Vector(mu);
+        e_nu = Lattice_Vector(nu);
+
+        for (a = 0;a<NUMGEN;a++) {
+          i = pack(flavor(mu, nu), x, a);
+
+          for (b = 0;b<NUMGEN;b++) {
+            j1 = pack(nu+num_chis+1, x+e_mu, b);
+            j2 = pack(nu+num_chis+1, x, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]+
+              V.get(x, mu).get(a, b)*BC(x, e_mu);
+            col[ix]= j1;
+            ix = find_index(i, j2, col, row);
+            m[ix]= m[ix]-
+              V.get(x+e_nu, mu).get(b, a);
+            col[ix]= j2;
+
+            j1 = pack(mu+num_chis+1, x+e_nu, b);
+            j2 = pack(mu+num_chis+1, x, b);
+            ix = find_index(i, j1, col, row);
+            m[ix]= m[ix]-
+              V.get(x, nu).get(a, b)*BC(x, e_nu);
+            col[ix]= j1;
+            ix = find_index(i, j2, col, row);
+            m[ix]= m[ix]+
+              V.get(x+e_mu, nu).get(b, a);
+            col[ix]= j2;
+
+          }
+        }
+
+      }
+    }
+  }
+
+  // Q-closed pieces
+
+  if (NUMLINK == 5) {
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (d = 0;d<NUMLINK;d++) {
+        for (e = d+1;e<NUMLINK;e++) {
+
+          for (l = 0;l<NUMGEN;l++) {
+            i = pack(flavor(d, e), x, l);
+
+            for (c = 0;c<NUMLINK;c++) {
+              if ((c == d)||(c == e)) continue;
+
+              e_c = Lattice_Vector(c);
+
+              for (a = 0;a<NUMLINK;a++) {
+                e_a = Lattice_Vector(a);
+                if ((a == c)||(a == d)||(a == e)) continue;
+                for (b = a+1;b<NUMLINK;b++) {
+                  e_b = Lattice_Vector(b);
+                  if ((b == c)||(b == d)||(b == e)) continue;
+
+                  for (k = 0;k<NUMGEN;k++) {
+
+                    j1 = pack(flavor(a, b), x-e_a-e_b, k);
+                    j2 = pack(flavor(a, b), x-e_a-e_b-e_c, k);
+
+                    ix = find_index(i, j1, col, row);
+                    m[ix]= m[ix]+0.5*perm[d][e][c][a][b]*
+                      conjug(V.get(x-e_a-e_b-e_c, c).get(l, k))*BC(x,-e_a,-e_b);
+                    col[ix]= j1;
+                    ix = find_index(i, j2, col, row);
+                    m[ix]= m[ix]-0.5*perm[d][e][c][a][b]*
+                      conjug(V.get(x-e_c, c).get(k, l))*BC(x,-e_a,-e_b,-e_c);
+                    col[ix]= j2;
+                  }}
+              }
+
+            }}}}}
+
+
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (a = 0;a<NUMLINK;a++) {
+        e_a = Lattice_Vector(a);
+        for (b = a+1;b<NUMLINK;b++) {
+          e_b = Lattice_Vector(b);
+
+          for (l = 0;l<NUMGEN;l++) {
+            i = pack(flavor(a, b), x, l);
+
+            for (c = 0;c<NUMLINK;c++) {
+              if ((c == a)||(c == b)) continue;
+
+              e_c = Lattice_Vector(c);
+
+              for (d = 0;d<NUMLINK;d++) {
+
+                if ((d == c)||(d == a)||(d == b)) continue;
+                for (e = d+1;e<NUMLINK;e++) {
+
+                  if ((e == c)||(e == a)||(e == b)) continue;
+                  for (k = 0;k<NUMGEN;k++) {
+
+                    j1 = pack(flavor(d, e), x+e_a+e_b+e_c, k);
+                    j2 = pack(flavor(d, e), x+e_a+e_b, k);
+
+                    ix = find_index(i, j1, col, row);
+                    m[ix]= m[ix]+0.5*perm[a][b][c][d][e]*
+                      conjug(V.get(x+e_a+e_b, c).get(l, k))*BC(x, e_a, e_b, e_c);
+                    col[ix]= j1;
+                    ix = find_index(i, j2, col, row);
+                    m[ix]= m[ix]-0.5*perm[a][b][c][d][e]*
+                      conjug(V.get(x-e_c, c).get(k, l))*BC(x, e_a, e_b);
+                    col[ix]= j2;
+
+                  }}
+              }
+
+            }}}}}
+  }
+
+  // remove blanks ...
+  int n2[LEN], c2[LEN*NONZEROES];
+  Complex m2[LEN*NONZEROES];
+
+  k = 0;
+  l = 0;
+  for (i = 0;i<LEN;i++) {
+    l+= num_in_row[i];
+    n2[i]= 0;
+    for (int j = row[i];j<row[i+1];j++) {
+      if (col[j]!=(-1)) {
+        m2[k]= m[j];
+        c2[k]= col[j];
+        k++;
+        n2[i]++;}
+    }
+  }
+
+  //cout << "Total number of nonzeroes " << k << "\t" << l << endl;
+  TOTALNONZEROES = k;
+  row[0]= 0;
+  for (i = 0;i<LEN;i++) {
+    if (n2[i]!= num_in_row[i]) {cout << "uh oh ..." << endl;}
+    row[i+1]= row[i]+n2[i];
+  }
+
+  for (i = 0;i<LEN;i++) {
+    for (int j = row[i];j<row[i+1];j++) {
+      if (c2[j]==(-1)) {cout << "oops i = " << i << "\t" << "j is " << j << endl;
+        cout << "row[i] is " << row[i] << "\t" << "row[i+1] is" << row[i+1] << endl;}
+      col[j]= c2[j];
+      m[j]= m2[j];
+    }}
+
+
+
+  // order by columns within a row block
+  col_order(m, col, row);
+
+  //for (i = 0;i<= LEN;i++) {
+  //f_op << row[i] << endl;
+  //}
+  //for (i = 0;i<(NONZEROES*LEN);i++) {
+  //f_op << col[i] << endl;
+  //}
+  //for (i = 0;i<(NONZEROES*LEN);i++) {
+  //f_op << m[i] << endl;
+  //}
+  //f_op.close();
+
+  if (first_time) {
+    cout << "Maximum number nonzeroes in row " << num_in_row[3] << "\n" << flush;
+    cout << "Total number of nonzeroes " << TOTALNONZEROES << endl;
+    first_time = 0;}
+
+  return;
 
 }
 
@@ -519,403 +519,402 @@ return;
 
 void mysort(Complex d[], int key[], int n)
 {
-        int i,newn;
-        Complex c;
-	int p;
-	
-	do{
-	newn=0;
-	for(i=0;i<n-1;i++){
-	if(key[i]>key[i+1]){p=key[i];c=d[i];key[i]=key[i+1];d[i]=d[i+1];
-	key[i+1]=p;d[i+1]=c;}
-	newn=i+1;}
-	
-	n=newn;
-	}while(n>1);
-	
-	return;
-	}
+  int i, newn;
+  Complex c;
+  int p;
 
-        
-void col_order(Complex m[], int col[], int row[]){
-Complex d[LEN];
-int key[LEN];
-int i,j;
+  do{
+    newn = 0;
+    for (i = 0;i<n-1;i++) {
+      if (key[i]>key[i+1]) {p = key[i];c = d[i];key[i]= key[i+1];d[i]= d[i+1];
+        key[i+1]= p;d[i+1]= c;}
+      newn = i+1;}
 
-for(i=0;i<LEN;i++){
+    n = newn;
+  }while(n>1);
 
-for(j=0;j<row[i+1]-row[i];j++){
-d[j]=m[row[i]+j];
-key[j]=col[row[i]+j];}
-
-mysort(d,key,row[i+1]-row[i]);
-
-for(j=0;j<row[i+1]-row[i];j++){
-m[row[i]+j]=d[j];
-col[row[i]+j]=key[j];}
-
-}
-
-// test row 
-//for(i=0;i<LEN;i++){
-//for(j=row[i];j<row[i]-1;j++){
-//if(col[j]>col[j+1]){cout << "error in col order " << endl;}
-//}}
-
-return;}
-
-
-Complex dot(Complex a[], Complex b[]){
-Complex dum=Complex(0.0,0.0);
-for(int i=0;i<LEN;i++){
-dum=dum+conjug(a[i])*b[i];
-}
-return(dum);
+  return;
 }
 
 
-void sparse_mult(Complex m[], int col[], int row[], int sign, Complex v[], Complex p[]){
-int i,j;
+void col_order(Complex m[], int col[], int row[]) {
+  Complex d[LEN];
+  int key[LEN];
+  int i, j;
 
-if(sign==(-1)){
-for(i=0;i<LEN;i++){
-v[i]=-1.0*conjug(v[i]);}
-}
+  for (i = 0;i<LEN;i++) {
 
-for(i=0;i<LEN;i++){
-p[i]=Complex();
-for(j=row[i];j<row[i+1];j++){
-if(col[j]!=(-1)){
-p[i]=p[i]+m[j]*v[col[j]];
-}
-}
-}
+    for (j = 0;j<row[i+1]-row[i];j++) {
+      d[j]= m[row[i]+j];
+      key[j]= col[row[i]+j];}
 
-if(sign==(-1)){
-for(i=0;i<LEN;i++){
-p[i]=conjug(p[i]);}
-}
+    mysort(d, key, row[i+1]-row[i]);
 
-return;
+    for (j = 0;j<row[i+1]-row[i];j++) {
+      m[row[i]+j]= d[j];
+      col[row[i]+j]= key[j];}
+
+  }
+
+  // test row
+  //for (i = 0;i<LEN;i++) {
+  //for (j = row[i];j<row[i]-1;j++) {
+  //if (col[j]>col[j+1]) {cout << "error in col order " << endl;}
+  //}}
+
+  return;}
+
+
+  Complex dot(Complex a[], Complex b[]) {
+    Complex dum = Complex(0.0, 0.0);
+    for (int i = 0;i<LEN;i++) {
+      dum = dum+conjug(a[i])*b[i];
+    }
+    return(dum);
+  }
+
+
+void sparse_mult(Complex m[], int col[], int row[], int sign, Complex v[], Complex p[]) {
+  int i, j;
+
+  if (sign ==(-1)) {
+    for (i = 0;i<LEN;i++) {
+      v[i]=-1.0*conjug(v[i]);}
+  }
+
+  for (i = 0;i<LEN;i++) {
+    p[i]= Complex();
+    for (j = row[i];j<row[i+1];j++) {
+      if (col[j]!=(-1)) {
+        p[i]= p[i]+m[j]*v[col[j]];
+      }
+    }
+  }
+
+  if (sign ==(-1)) {
+    for (i = 0;i<LEN;i++) {
+      p[i]= conjug(p[i]);}
+  }
+
+  return;
 }
 
 #ifdef FULLMATRIX
-void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]){
-int sites,a,b,j1,j2,i,mu,nu,l,m,d,e,c,index,num_chis;
-Lattice_Vector x,e_mu,e_nu,e_a,e_b,e_c;
-Gauge_Field Udag,Udtr;
-UPlaq_Field P;
-Complex W,Z;
+void full_fermion_op(const Gauge_Field &U, Complex M[LEN][LEN]) {
+  int sites, a, b, j1, j2, i, mu, nu, l, m, d, e, c, index, num_chis;
+  Lattice_Vector x, e_mu, e_nu, e_a, e_b, e_c;
+  Gauge_Field Udag, Udtr;
+  UPlaq_Field P;
+  Complex W, Z;
 
-Udag=Adj(U);
-
-
-for(j1=0;j1<LEN;j1++){
-for(j2=0;j2<LEN;j2++){
-M[j1][j2]=Complex();
-}}
+  Udag = Adj(U);
 
 
-// eta dmubar psi_mu
+  for (j1 = 0;j1<LEN;j1++) {
+    for (j2 = 0;j2<LEN;j2++) {
+      M[j1][j2]= Complex();
+    }}
 
-num_chis=(NUMLINK*(NUMLINK-1))/2;
-//cout<< "number of chis " << num_chis << "\n" << flush;
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMGEN;a++){
+  // eta dmubar psi_mu
 
-i=pack(0,x,a);
+  num_chis =(NUMLINK*(NUMLINK-1))/2;
+  //cout<< "number of chis " << num_chis << "\n" << flush;
 
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-for(b=0;b<NUMGEN;b++){
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (a = 0;a<NUMGEN;a++) {
 
-j1=pack(num_chis+1+mu,x,b);
-j2=pack(num_chis+1+mu,x-e_mu,b);
-M[i][j1]=M[i][j1]+Tr(Lambda[b]*Udag.get(x,mu)*Lambda[a]);
-M[i][j2]=M[i][j2]-Tr(Lambda[a]*Udag.get(x-e_mu,mu)*Lambda[b])*BC(x,-e_mu);
+      i = pack(0, x, a);
+
+      for (mu = 0;mu<NUMLINK;mu++) {
+        e_mu = Lattice_Vector(mu);
+        for (b = 0;b<NUMGEN;b++) {
+
+          j1 = pack(num_chis+1+mu, x, b);
+          j2 = pack(num_chis+1+mu, x-e_mu, b);
+          M[i][j1]= M[i][j1]+Tr(Lambda[b]*Udag.get(x, mu)*Lambda[a]);
+          M[i][j2]= M[i][j2]-Tr(Lambda[a]*Udag.get(x-e_mu, mu)*Lambda[b])*BC(x,-e_mu);
+        }
+      }
+
+    }
+  }
+  // psi_mu dbarT eta
+
+
+
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+    for (a = 0;a<NUMGEN;a++) {
+      for (mu = 0;mu<NUMLINK;mu++) {
+        e_mu = Lattice_Vector(mu);
+        i = pack(mu+num_chis+1, x, a);
+
+        for (b = 0;b<NUMGEN;b++) {
+          j1 = pack(0, x+e_mu, b);
+          j2 = pack(0, x, b);
+          M[i][j1]= M[i][j1]+Tr(Lambda[b]*Udag.get(x, mu)*Lambda[a])*BC(x, e_mu);
+          M[i][j2]= M[i][j2]-Tr(Lambda[a]*Udag.get(x, mu)*Lambda[b]);
+        }}}}
+
+
+  // chi_{munu} dmu psi_nu
+
+
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+
+    for (mu = 0;mu<NUMLINK;mu++) {
+      e_mu = Lattice_Vector(mu);
+
+      for (nu = mu+1;nu<NUMLINK;nu++) {
+        e_nu = Lattice_Vector(nu);
+
+        index = flavor(mu, nu);
+        //cout << "index is " << index << "\n" << flush;
+        for (a = 0;a<NUMGEN;a++) {
+          i = pack(index, x, a);
+
+          for (b = 0;b<NUMGEN;b++) {
+
+            j1 = pack(num_chis+1+nu, x+e_mu, b);
+            j2 = pack(num_chis+1+nu, x, b);
+            M[i][j1]= M[i][j1]+Tr(Lambda[a]*U.get(x, mu)*Lambda[b])*BC(x, e_mu);
+            M[i][j2]= M[i][j2]-Tr(Lambda[b]*U.get(x+e_nu, mu)*Lambda[a]);
+            j1 = pack(num_chis+1+mu, x+e_nu, b);
+            j2 = pack(num_chis+1+mu, x, b);
+            M[i][j1]= M[i][j1]-Tr(Lambda[a]*U.get(x, nu)*Lambda[b])*BC(x, e_nu);
+            M[i][j2]= M[i][j2]+Tr(Lambda[b]*U.get(x+e_mu, nu)*Lambda[a]);
+
+          }}}}}
+  // psi_nu dmu chi_{munu}
+
+
+  sites = 0;
+  while(loop_over_lattice(x, sites)) {
+
+    for (nu = 0;nu<NUMLINK;nu++) {
+      e_nu = Lattice_Vector(nu);
+
+      for (a = 0;a<NUMGEN;a++) {
+
+        for (mu = nu+1;mu<NUMLINK;mu++) {
+          e_mu = Lattice_Vector(mu);
+
+          index = flavor(nu, mu);
+          //cout << "index is " << index << "\n" << flush;
+          for (b = 0;b<NUMGEN;b++) {
+
+            i = pack(num_chis+1+nu, x, a);
+            j1 = pack(index, x, b);
+            j2 = pack(index, x-e_mu, b);
+            M[i][j1]= M[i][j1]-Tr(Lambda[a]*U.get(x+e_nu, mu)*Lambda[b]);
+            M[i][j2]= M[i][j2]+Tr(Lambda[b]*U.get(x-e_mu, mu)*Lambda[a])*BC(x,-e_mu);
+            i = pack(num_chis+1+mu, x, a);
+            j1 = pack(index, x, b);
+            j2 = pack(index, x-e_nu, b);
+            M[i][j1]= M[i][j1]+Tr(Lambda[a]*U.get(x+e_mu, nu)*Lambda[b]);
+            M[i][j2]= M[i][j2]-Tr(Lambda[b]*U.get(x-e_nu, nu)*Lambda[a])*BC(x,-e_nu);
+          }
+        }
+      }
+    }}
+
+
+  // Q-closed term
+
+  if (NUMLINK == 5) {
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (d = 0;d<NUMLINK;d++) {
+        for (e = d+1;e<NUMLINK;e++) {
+
+          for (l = 0;l<NUMGEN;l++) {
+            i = pack(flavor(d, e), x, l);
+
+            for (c = 0;c<NUMLINK;c++) {
+              if ((c == d)||(c == e)) continue;
+
+              e_c = Lattice_Vector(c);
+
+              for (a = 0;a<NUMLINK;a++) {
+                e_a = Lattice_Vector(a);
+                if ((a == c)||(a == d)||(a == e)) continue;
+                for (b = a+1;b<NUMLINK;b++) {
+                  e_b = Lattice_Vector(b);
+                  if ((b == c)||(b == d)||(b == e)) continue;
+
+                  for (m = 0;m<NUMGEN;m++) {
+
+                    j1 = pack(flavor(a, b), x-e_a-e_b, m);
+                    j2 = pack(flavor(a, b), x-e_a-e_b-e_c, m);
+
+                    M[i][j1]= M[i][j1]+0.5*perm[d][e][c][a][b]*
+                      Tr(Lambda[m]*Udag.get(x-e_a-e_b-e_c, c)*Lambda[l])*BC(x,-e_a,-e_b);
+                    M[i][j2]= M[i][j2]-0.5*perm[d][e][c][a][b]*
+                      Tr(Lambda[l]*Udag.get(x-e_c, c)*Lambda[m])*BC(x,-e_a,-e_b,-e_c);
+
+                  }}
+              }
+
+            }}}}}
+
+
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (a = 0;a<NUMLINK;a++) {
+        e_a = Lattice_Vector(a);
+        for (b = a+1;b<NUMLINK;b++) {
+          e_b = Lattice_Vector(b);
+
+          for (l = 0;l<NUMGEN;l++) {
+            i = pack(flavor(a, b), x, l);
+
+            for (c = 0;c<NUMLINK;c++) {
+              if ((c == a)||(c == b)) continue;
+
+              e_c = Lattice_Vector(c);
+
+              for (d = 0;d<NUMLINK;d++) {
+
+                if ((d == c)||(d == a)||(d == b)) continue;
+                for (e = d+1;e<NUMLINK;e++) {
+
+                  if ((e == c)||(e == a)||(e == b)) continue;
+                  for (m = 0;m<NUMGEN;m++) {
+
+                    j1 = pack(flavor(d, e), x+e_a+e_b+e_c, m);
+                    j2 = pack(flavor(d, e), x+e_a+e_b, m);
+
+                    M[i][j1]= M[i][j1]+0.5*perm[a][b][c][d][e]*
+                      Tr(Lambda[m]*Udag.get(x+e_a+e_b, c)*Lambda[l])*BC(x, e_a, e_b, e_c);
+                    M[i][j2]= M[i][j2]-0.5*perm[a][b][c][d][e]*
+                      Tr(Lambda[l]*Udag.get(x-e_c, c)*Lambda[m])*BC(x, e_a, e_b);
+
+                  }}
+              }
+
+            }}}}}
+  }
+
+
+  // SIMON: susy det term modification
+
+  if (NUMGEN ==(NCOLOR*NCOLOR)) {
+
+    P = Plaq(U);
+    sites = 0;
+    while(loop_over_lattice(x, sites)) {
+      for (mu = 0;mu<NUMLINK;mu++) {
+        for (nu = 0;nu<NUMLINK;nu++) {
+          if (mu == nu) continue;
+          e_mu = Lattice_Vector(mu);
+
+          W = det(P.get(x, mu, nu))-Complex(1.0, 0.0);
+
+          Z = sqrt(1.0*NCOLOR)*Complex(0.0, 1.0)*(Complex(1.0, 0.0)+W);
+          i = pack(0, x, NUMGEN-1);
+
+          for (b = 0;b<NUMGEN;b++) {
+            j1 = pack(num_chis+1+mu, x, b);
+            M[i][j1]= M[i][j1]+G*0.5*Z*Tr(inverse(U.get(x, mu))*Lambda[b]);
+
+            j1 = pack(num_chis+1+nu, x+e_mu, b);
+            M[i][j1]= M[i][j1]+G*0.5*Z*Tr(inverse(U.get(x+e_mu, nu))*Lambda[b])*BC(x, e_mu);
+          }
+
+          j1 = pack(0, x, NUMGEN-1);
+
+          for (b = 0;b<NUMGEN;b++) {
+            i = pack(num_chis+1+mu, x, b);
+            M[i][j1]= M[i][j1]-G*0.5*Z*Tr(inverse(U.get(x, mu))*Lambda[b]);
+
+            i = pack(num_chis+1+nu, x+e_mu, b);
+            M[i][j1]= M[i][j1]-G*0.5*Z*Tr(inverse(U.get(x+e_mu, nu))*Lambda[b])*BC(x, e_mu);
+          }
+
+        }}}
+  }
+
+  //test antisymmetric nature
+  for (j1 = 0;j1<LEN;j1++) {
+    for (j2 = j1+1;j2<LEN;j2++) {
+      //cout << "M[j1][j2] is " << M[j1][j2] << "\n" <<flush;
+      Complex dum = M[j1][j2]+M[j2][j1];
+      if (dum.norm()>0.00000001) {
+        cout << "problem " << j1 << "\t" << j2 << "\t" <<
+          M[j1][j2] << "\t" << M[j2][j1] << "\n" << flush;}
+    }
+  }
+
+
+  return;
 }
-}
 
-}
-}
-// psi_mu dbarT eta
 
-
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMGEN;a++){
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-i=pack(mu+num_chis+1,x,a);
-
-for(b=0;b<NUMGEN;b++){
-j1=pack(0,x+e_mu,b);
-j2=pack(0,x,b);
-M[i][j1]=M[i][j1]+Tr(Lambda[b]*Udag.get(x,mu)*Lambda[a])*BC(x,e_mu);
-M[i][j2]=M[i][j2]-Tr(Lambda[a]*Udag.get(x,mu)*Lambda[b]);
-}}}}
-
-
-// chi_{munu} dmu psi_nu
-
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-
-for(mu=0;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-
-for(nu=mu+1;nu<NUMLINK;nu++){
-e_nu=Lattice_Vector(nu);
-
-index=flavor(mu,nu);
-//cout << "index is " << index << "\n" << flush;
-for(a=0;a<NUMGEN;a++){
-i=pack(index,x,a);
-
-for(b=0;b<NUMGEN;b++){
-
-j1=pack(num_chis+1+nu,x+e_mu,b);
-j2=pack(num_chis+1+nu,x,b);
-M[i][j1]=M[i][j1]+Tr(Lambda[a]*U.get(x,mu)*Lambda[b])*BC(x,e_mu);
-M[i][j2]=M[i][j2]-Tr(Lambda[b]*U.get(x+e_nu,mu)*Lambda[a]);
-j1=pack(num_chis+1+mu,x+e_nu,b);
-j2=pack(num_chis+1+mu,x,b);
-M[i][j1]=M[i][j1]-Tr(Lambda[a]*U.get(x,nu)*Lambda[b])*BC(x,e_nu);
-M[i][j2]=M[i][j2]+Tr(Lambda[b]*U.get(x+e_mu,nu)*Lambda[a]);
-
-}}}}}
-// psi_nu dmu chi_{munu}
-
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-
-for(nu=0;nu<NUMLINK;nu++){
-e_nu=Lattice_Vector(nu);
-
-for(a=0;a<NUMGEN;a++){
-
-for(mu=nu+1;mu<NUMLINK;mu++){
-e_mu=Lattice_Vector(mu);
-
-index=flavor(nu,mu);
-//cout << "index is " << index << "\n" << flush;
-for(b=0;b<NUMGEN;b++){
-
-i=pack(num_chis+1+nu,x,a);
-j1=pack(index,x,b);
-j2=pack(index,x-e_mu,b);
-M[i][j1]=M[i][j1]-Tr(Lambda[a]*U.get(x+e_nu,mu)*Lambda[b]);
-M[i][j2]=M[i][j2]+Tr(Lambda[b]*U.get(x-e_mu,mu)*Lambda[a])*BC(x,-e_mu);
-i=pack(num_chis+1+mu,x,a);
-j1=pack(index,x,b);
-j2=pack(index,x-e_nu,b);
-M[i][j1]=M[i][j1]+Tr(Lambda[a]*U.get(x+e_mu,nu)*Lambda[b]);
-M[i][j2]=M[i][j2]-Tr(Lambda[b]*U.get(x-e_nu,nu)*Lambda[a])*BC(x,-e_nu);
-}
-}
-}
-}}
-
-
-// Q-closed term
-
-if(NUMLINK==5){
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(d=0;d<NUMLINK;d++){
-for(e=d+1;e<NUMLINK;e++){
-
-for(l=0;l<NUMGEN;l++){
-i=pack(flavor(d,e),x,l);
-
-for(c=0;c<NUMLINK;c++){
-if((c==d)||(c==e)) continue;
-
-e_c=Lattice_Vector(c);
-
-for(a=0;a<NUMLINK;a++){
-e_a=Lattice_Vector(a);
-if((a==c)||(a==d)||(a==e)) continue;
-for(b=a+1;b<NUMLINK;b++){
-e_b=Lattice_Vector(b);
-if((b==c)||(b==d)||(b==e)) continue;
-
-for(m=0;m<NUMGEN;m++){
-
-j1=pack(flavor(a,b),x-e_a-e_b,m);
-j2=pack(flavor(a,b),x-e_a-e_b-e_c,m);
-
-M[i][j1]=M[i][j1]+0.5*perm[d][e][c][a][b]*
-Tr(Lambda[m]*Udag.get(x-e_a-e_b-e_c,c)*Lambda[l])*BC(x,-e_a,-e_b);
-M[i][j2]=M[i][j2]-0.5*perm[d][e][c][a][b]*
-Tr(Lambda[l]*Udag.get(x-e_c,c)*Lambda[m])*BC(x,-e_a,-e_b,-e_c);
-
-}}
-}
-
-}}}}}
-
-
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(a=0;a<NUMLINK;a++){
-e_a=Lattice_Vector(a);
-for(b=a+1;b<NUMLINK;b++){
-e_b=Lattice_Vector(b);
-
-for(l=0;l<NUMGEN;l++){
-i=pack(flavor(a,b),x,l);
-
-for(c=0;c<NUMLINK;c++){
-if((c==a)||(c==b)) continue;
-
-e_c=Lattice_Vector(c);
-
-for(d=0;d<NUMLINK;d++){
-
-if((d==c)||(d==a)||(d==b)) continue;
-for(e=d+1;e<NUMLINK;e++){
-
-if((e==c)||(e==a)||(e==b)) continue;
-for(m=0;m<NUMGEN;m++){
-
-j1=pack(flavor(d,e),x+e_a+e_b+e_c,m);
-j2=pack(flavor(d,e),x+e_a+e_b,m);
-
-M[i][j1]=M[i][j1]+0.5*perm[a][b][c][d][e]*
-Tr(Lambda[m]*Udag.get(x+e_a+e_b,c)*Lambda[l])*BC(x,e_a,e_b,e_c);
-M[i][j2]=M[i][j2]-0.5*perm[a][b][c][d][e]*
-Tr(Lambda[l]*Udag.get(x-e_c,c)*Lambda[m])*BC(x,e_a,e_b);
-
-}}
-}
-
-}}}}}
-}
-
-
-// SIMON: susy det term modification
-
-if(NUMGEN==(NCOLOR*NCOLOR)){
-
-P=Plaq(U);
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(mu=0;mu<NUMLINK;mu++){
-for(nu=0;nu<NUMLINK;nu++){
-if(mu==nu) continue;
-e_mu=Lattice_Vector(mu);
-
-W=det(P.get(x,mu,nu))-Complex(1.0,0.0);
-
-Z=sqrt(1.0*NCOLOR)*Complex(0.0,1.0)*(Complex(1.0,0.0)+W);
-i=pack(0,x,NUMGEN-1);
-
-for(b=0;b<NUMGEN;b++){
-j1=pack(num_chis+1+mu,x,b);
-M[i][j1]=M[i][j1]+G*0.5*Z*Tr(inverse(U.get(x,mu))*Lambda[b]);
-
-j1=pack(num_chis+1+nu,x+e_mu,b);
-M[i][j1]=M[i][j1]+G*0.5*Z*Tr(inverse(U.get(x+e_mu,nu))*Lambda[b])*BC(x,e_mu);
-}
-
-j1=pack(0,x,NUMGEN-1);
-
-for(b=0;b<NUMGEN;b++){
-i=pack(num_chis+1+mu,x,b);
-M[i][j1]=M[i][j1]-G*0.5*Z*Tr(inverse(U.get(x,mu))*Lambda[b]);
-
-i=pack(num_chis+1+nu,x+e_mu,b);
-M[i][j1]=M[i][j1]-G*0.5*Z*Tr(inverse(U.get(x+e_mu,nu))*Lambda[b])*BC(x,e_mu);
-}
-
-}}}
-}
-
-
-//test antisymmetric nature
-for(j1=0;j1<LEN;j1++){
-for(j2=j1+1;j2<LEN;j2++){
-//cout << "M[j1][j2] is " << M[j1][j2] << "\n" <<flush;
-Complex dum=M[j1][j2]+M[j2][j1];
-if(dum.norm()>0.00000001) {
-cout << "problem " << j1 << "\t" << j2 << "\t" << 
-M[j1][j2] << "\t" << M[j2][j1] << "\n" << flush;}
-}
-}
-
-
-return;
-}
-
-
-double cnorm(const Complex &c){
-double dum;
-dum=c.real()*c.real()+c.imag()*c.imag();
-return(sqrt(dum));
+double cnorm(const Complex &c) {
+  double dum;
+  dum = c.real()*c.real()+c.imag()*c.imag();
+  return(sqrt(dum));
 }
 
 /*
-void eigenvalues(Complex M[LEN][LEN]){
-static int firsttime=1;
-static ofstream f_feigen,f_det;
-int i,j,ok,c1,c2,c3;
-char c4;
-Complex temp[2*LEN+1];
-double b[2*LEN],dummy[2],work[4*LEN];
-double at[2*LEN*LEN];
+void eigenvalues(Complex M[LEN][LEN]) {
+  static int firsttime = 1;
+  static ofstream f_feigen, f_det;
+  int i, j, ok, c1, c2, c3;
+  char c4;
+  Complex temp[2*LEN+1];
+  double b[2*LEN], dummy[2], work[4*LEN];
+  double at[2*LEN*LEN];
 
-if(firsttime){
-        f_feigen.open("feigen",ios::app);
-        if(f_feigen.bad()){
-        cout << "failed to open feigen file\n" << flush ;}
-        f_det.open("detarg",ios::app);
-        if(f_det.bad()){
-        cout << "failed to open argdet file\n" << flush;}
-        firsttime=0;
-}
+  if (firsttime) {
+   f_feigen.open("feigen", ios::app);
+   if (f_feigen.bad()) {
+   cout << "failed to open feigen file\n" << flush ;}
+   f_det.open("detarg", ios::app);
+   if (f_det.bad()) {
+     cout << "failed to open argdet file\n" << flush;}
+     firsttime = 0;
+   }
 
-if(1){
-for(i=0;i<LEN;i++){
-for(j=0;j<LEN;j++){
-at[2*(j+LEN*i)]=M[j][i].real();
-at[2*(j+LEN*i)+1]=M[j][i].imag();
-}
-}
+   if (1) {
+   for (i = 0;i<LEN;i++) {
+   for (j = 0;j<LEN;j++) {
+   at[2*(j+LEN*i)]= M[j][i].real();
+   at[2*(j+LEN*i)+1]= M[j][i].imag();
+   }
+   }
 
-c1=LEN;
-c2=2*LEN;
-c3=1;
-c4='N';
+   c1 = LEN;
+   c2 = 2*LEN;
+   c3 = 1;
+   c4 ='N';
 
-zgeev_(&c4,&c4,&c1,at,&c1,b,dummy,&c3,dummy,&c3,work,&c2,work,&ok);
+   zgeev_(&c4,&c4,&c1, at,&c1, b, dummy,&c3, dummy,&c3, work,&c2, work,&ok);
 
-for(j=0;j<2*LEN;j=j+2){
-temp[j/2+1]=Complex(b[j],b[j+1]);}
+   for (j = 0;j<2*LEN;j = j+2) {
+   temp[j/2+1]= Complex(b[j], b[j+1]);}
 
-ceigsrt(temp,LEN);
-int SUB=0;
+   ceigsrt(temp, LEN);
+   int SUB = 0;
 
-double arg[LEN+1];
-Complex phase[LEN+1];
+   double arg[LEN+1];
+   Complex phase[LEN+1];
 
-for(i=1;i<=(LEN-SUB);i++){
-arg[i]=0.0;
-for(j=1;j<=i;j++){
-arg[i]=arg[i]+atan2(temp[j].imag(),temp[j].real());
-}
-phase[i]=Complex(cos(arg[i]),sin(arg[i]));}
+   for (i = 1;i<=(LEN-SUB);i++) {
+   arg[i]= 0.0;
+   for (j = 1;j<= i;j++) {
+   arg[i]= arg[i]+atan2(temp[j].imag(), temp[j].real());
+   }
+   phase[i]= Complex(cos(arg[i]), sin(arg[i]));}
 
 
-Complex tmp;
-int count=0;
-for(i=1;i<=(LEN);i++){
-if(temp[i].norm()<0.000001) {count++;}
+   Complex tmp;
+   int count = 0;
+   for (i = 1;i<=(LEN);i++) {
+   if (temp[i].norm()<0.000001) {count++;}
 //f_feigen << i << "\t" << phase[i] << endl;
 f_feigen << temp[i] << endl;}
 
@@ -923,102 +922,107 @@ f_feigen << "\n";
 
 cout << "number of zeromodes  is " << count << endl;
 
-f_det << Complex(cos(arg[LEN]),sin(arg[LEN])) << endl;
-
-}
-
-
-return;
+f_det << Complex(cos(arg[LEN]), sin(arg[LEN])) << endl;
+  }
+  return;
 }
 */
 
-Complex Pfaffian(Complex M[LEN][LEN])
-{
-	int i,j,k,jpiv,interchange=1;
-        static int firsttime=1;
-	double pivot,totalangle,angle,cosine,sine,mag;
-	Complex dum[LEN],scale,f;
-//        cout << "in Pfaffian\n" << flush;
-        static ofstream f_pfaff;
-       
-        if(firsttime){ 
-        f_pfaff.open("pfaffian",ios::app);
-        if(f_pfaff.bad()){
-        cout << "failed to open pfaffian file\n" << flush ;}
-        firsttime=0;
-}
-// loop over all rows in steps of 2
-	for(i=0;i<LEN-2;i+=2){
+Complex Pfaffian(Complex M[LEN][LEN]) {
+  int i, j, k, jpiv, interchange = 1;
+  static int firsttime = 1;
+  double pivot, totalangle, angle, cosine, sine, mag;
+  Complex dum, scale, f;
+  //        cout << "in Pfaffian\n" << flush;
+  static ofstream f_pfaff;
 
-// first row i:	
-// find col whose ith component is biggest to use as pivot
-	pivot=cnorm(M[i][i+1]);
-	jpiv=i+1;
-	for(j=i+2;j<LEN;j++){
-	if(cnorm(M[i][j])>pivot){pivot=cnorm(M[i][j]);jpiv=j;}}
+  if (firsttime) {
+    f_pfaff.open("pfaffian", ios::app);
+    if (f_pfaff.bad()) {
+      cout << "failed to open pfaffian file\n" << flush ;}
+    firsttime = 0;
+  }
 
-// interchange col(i+1) with col(jpiv)
-        for(j=0;j<LEN;j++){
-	dum[j]=M[j][i+1];}
-	for(j=0;j<LEN;j++){
-	M[j][i+1]=M[j][jpiv];
-	M[j][jpiv]=dum[j];}
-// interchange row(i+1) with row(jpiv)
-	for(j=0;j<LEN;j++){
-	dum[j]=M[i+1][j];}
-	for(j=0;j<LEN;j++){
-	M[i+1][j]=M[jpiv][j];
-	M[jpiv][j]=dum[j];}
-	
-	if(jpiv!=i+1) interchange*=(-1);
-	
-// using this zero progressively elements of row M[i][j], j=i+2...LEN-1
-        for(j=i+2;j<LEN;j++){
-	scale=M[i][j]/M[i][i+1];
-	
-	for(k=0;k<LEN;k++){
-	M[k][j]=M[k][j]-scale*M[k][i+1];}
-// zero out elements along corresponding column M[j][i] too
-	for(k=0;k<LEN;k++){
-	M[j][k]=M[j][k]-scale*M[i+1][k];}
-	}
+  // Loop over all rows in steps of 2
+  for (i = 0; i < LEN - 2; i += 2) {
+    // Find column whose ith component is biggest to use as pivot
+    pivot = cnorm(M[i][i + 1]);
+    jpiv = i + 1;
+    for (j = i + 2; j < LEN; j++) {
+      if (cnorm(M[i][j]) > pivot) {
+        pivot = cnorm(M[i][j]);
+        jpiv = j;
+      }
+    }
 
-	
-// next row i+1;
-        
-	// using this zero progressively elements M[i][j], j=i+2...LEN-1
-        for(j=i+2;j<LEN;j++){
-	scale=M[i+1][j]/M[i+1][i];
-	
-	for(k=0;k<LEN;k++){
-	M[k][j]=M[k][j]-scale*M[k][i];}
-// zero out elements along corresponding column too
-	for(k=0;k<LEN;k++){
-	M[j][k]=M[j][k]-scale*M[i][k];}
-	}
-	
-	}
-	
-	
-	f=Complex(1.0,0.0);
-        mag=0.0;
-	totalangle=0.0;
-	for(i=0;i<LEN;i+=2){
-        cosine=M[i][i+1].real()/M[i][i+1].norm();
-        sine=M[i][i+1].imag()/M[i][i+1].norm();
-        if ((cosine>0.0) && (sine>0.0)) angle=acos(cosine);
-        if ((cosine<0.0) && (sine>0.0)) angle=acos(cosine);
-        if ((cosine>0.0) && (sine<0.0)) angle=4*acos(0.0)-1.0*acos(cosine);
-        if ((cosine<0.0) && (sine<0.0)) angle=4*acos(0.0)-1.0*acos(cosine);
-        mag+=log(M[i][i+1].norm());
-        totalangle+=angle;
-	f=f*M[i][i+1];
-	}
-        
-        cout << "Pfaffian is " << Complex(cos(totalangle)*interchange,sin(totalangle)*interchange) << endl;
+    // If necessary, interchange M[j][i + 1] <--> M[j][jpiv]
+    //                       and M[i + 1][j] <--> M[jpiv][j]
+    if (jpiv != i + 1) {
+      interchange *= -1;
+      // Interchange column(i + 1) with column(jpiv)
+      for (j = 0; j < LEN; j++) {
+        dum = M[j][i + 1];
+        M[j][i + 1] = M[j][jpiv];
+        M[j][jpiv] = dum;
+      }
+      // Interchange row(i + 1) with row(jpiv)
+      for (j = 0; j < LEN; j++) {
+        dum = M[i + 1][j];
+        M[i + 1][j] = M[jpiv][j];
+        M[jpiv][j] = dum;
+      }
+    }
 
-        f_pfaff << mag << "\t" << cos(totalangle)*interchange << "\t" 
-                << sin(totalangle)*interchange << "\n" << flush;
-return (f*interchange);
+    // Progressively zero out elements j = i + 2, ..., LEN - 1 of row M[i]
+    // Also zero out elements along the corresponding column M[:][i]
+    for (j = i + 2; j < LEN; j++) {
+      scale = M[i][j] / M[i][i + 1];
+      for (k = 0; k < LEN; k++) {
+        M[k][j] = M[k][j] - scale * M[k][i + 1];
+        M[j][k] = M[j][k] - scale * M[i + 1][k];
+      }
+    }
+
+    // Progressively zero out elements j = i + 2, ..., LEN - 1 of row M[i + 1]
+    // Also zero out elements along the corresponding column M[:][i + 1]
+    for (j = i + 2; j < LEN; j++) {
+      scale = M[i + 1][j] / M[i + 1][i];
+      for (k = 0; k < LEN; k++) {
+        M[k][j] = M[k][j] - scale * M[k][i];
+        M[j][k] = M[j][k] - scale * M[i][k];
+      }
+    }
+  }
+
+  f = Complex(1.0, 0.0);
+  mag = 0.0;
+  totalangle = 0.0;
+  double TWOPI = 4.0 * acos(0.0);
+  for (i = 0; i < LEN; i += 2) {
+    cosine = M[i][i + 1].real() / M[i][i + 1].norm();
+    sine = M[i][i + 1].imag() / M[i][i + 1].norm();
+    if (cosine >= 0.0) {
+      if (sine >= 0.0)
+        angle = acos(cosine);
+      else
+        angle = TWOPI - acos(cosine);
+    }
+    else {    // cosine < 0.0
+      if (sine >= 0.0)
+        angle = acos(cosine);
+      else
+        angle = TWOPI - acos(cosine);
+    }
+    mag += log(M[i][i + 1].norm());
+    totalangle += angle;
+    f = f * M[i][i + 1];
+  }
+
+  cout << "Pfaffian is " << Complex(cos(totalangle)*interchange, sin(totalangle)*interchange) << endl;
+
+  f_pfaff << mag << "\t" << cos(totalangle)*interchange << "\t"
+    << sin(totalangle)*interchange << "\n" << flush;
+
+  return (f * interchange);
 }
 #endif

--- a/measure.cpp
+++ b/measure.cpp
@@ -1,123 +1,119 @@
-#include "measure.h"  
+#include "measure.h"
 
-void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num){
-
-	static int first_time=1;
-	static ofstream f_data,f_av,f_scalars;
-	static ofstream f_line,f_kon1,f_kon2, f_line_z;
-        static ofstream f_loop,f_loop2,f_det;
-        double act_s,act_F,mass,t1,t2;
-	double eigenvals[SITES][NUMLINK][NCOLOR];
-	int i,j,k,sites,mu,r,m;
-	Lattice_Vector x;
-	Gauge_Field Utmp,U2,U3,U4;
-        Complex av2,d;
-	UPlaq_Field B;
-        double wilson[LX][T],wilson2[LX][T];
+void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num) {
+  static int first_time=1;
+  static ofstream f_data,f_av,f_scalars;
+  static ofstream f_line,f_kon1,f_kon2, f_line_z;
+  static ofstream f_loop,f_loop2,f_det;
+  double act_s,act_F,mass,t1,t2;
+  double eigenvals[SITES][NUMLINK][NCOLOR];
+  int i,j,k,sites,mu,r,m;
+  Lattice_Vector x;
+  Gauge_Field Utmp,U2,U3,U4;
+  Complex av2,d;
+  UPlaq_Field B;
+  double wilson[LX][T],wilson2[LX][T];
 #ifdef FULLMATRIX
-Complex M[LEN][LEN];
-#endif 
-        cout << " in measure \n" << flush;	
-	if(first_time){
-	f_data.open("data",ios::app);
-	if(f_data.bad()){ 
-	cout << "failed to open data file\n" << flush ;}
+  Complex M[LEN][LEN];
+#endif
+  cout << " in measure \n" << flush;
+  if(first_time){
+    f_data.open("data",ios::app);
+    if(f_data.bad()){
+      cout << "failed to open data file\n" << flush ;}
 
-        f_av.open("eigenvalues",ios::app);
-        if(f_av.bad()){
-        cout << "failed to open eigenvalues file\n" << flush;}
+    f_av.open("eigenvalues",ios::app);
+    if(f_av.bad()){
+      cout << "failed to open eigenvalues file\n" << flush;}
 
-        f_scalars.open("scalars",ios::app);
-        if(f_scalars.bad()){
-        cout << "failed to open scalars file\n" << flush;}
+    f_scalars.open("scalars",ios::app);
+    if(f_scalars.bad()){
+      cout << "failed to open scalars file\n" << flush;}
 
-	f_line.open("lines",ios::app);
-	if(f_line.bad()){
-	cerr << "failed to open lines_t file" << "\n";exit(1);}
-
-
-	f_line_z.open("lines_z",ios::app);
-        if(f_line_z.bad()){
-            cerr << "failed to open lines_z file" << "\n";exit(1);}
-
-        f_loop.open("loops",ios::app);
-        if(f_loop.bad()){
-        cerr << "failed to open loops file" << "\n";exit(1);}
-       
-        f_loop2.open("loops2",ios::app);
-        if(f_loop2.bad()){
-        cerr << "failed to open loops2 file" << "\n";exit(1);} 
-
-        f_det.open("det",ios::app);
-        if(f_det.bad()){cerr << "failed to open det file" << "\n";exit(1);}
-        
-
-        f_kon1.open("kon1",ios::app);
-        if(f_kon1.bad()){cerr << "failed to open kon1 file" << "\n";exit(1);}
-
-        
-        f_kon2.open("kon2",ios::app);
-        if(f_kon2.bad()){cerr << "failed to open kon2 file" << "\n";exit(1);}
-
-	first_time=0;
-	}
-
-        unit(U,U2);     // Polar-decomposition employed for holographic tests // 
-	  
-	// check Bianchi
-	if(NUMLINK==5){
-	B=Bianchi(U);
-	cout << "Bianchi is " << Tr(B*Adj(B)).real() << flush << "\n";
-	}
-	
-	f_line  << line(U2,D-1) << "\n" << flush;      // Polyakov line along time // 
-	f_line_z  << line(U2,D-2) << "\n" << flush;    // Polyakov line along z direction // 
-    
-		 
-    loop(U,wilson);  
-    loop(U2,wilson2);
-	f_kon1 << konishi(U) << endl;
-    f_kon2 << konishi(U2)/16.0<< endl;
-
-        for(r=1;r<=(LX/2);r++){
-        for(m=1;m<=(T/2);m++){
-	f_loop << r << "\t" << m <<  "\t" << wilson[r][m]/((D-1)*SITES) << "\t" << flush;}
-        }
-        f_loop  << "\n" << flush;
+    f_line.open("lines",ios::app);
+    if(f_line.bad()){
+      cerr << "failed to open lines_t file" << "\n";exit(1);}
 
 
-for(r=1;r<=(LX/2);r++){
-        for(m=1;m<=(T/2);m++){
-        f_loop2 << r << "\t" << m <<  "\t" << wilson2[r][m]/((D-1)*SITES) << "\t" << flush;}
-        }
-        f_loop2  << "\n" << flush; 
+    f_line_z.open("lines_z",ios::app);
+    if(f_line_z.bad()){
+      cerr << "failed to open lines_z file" << "\n";exit(1);}
 
-        obs(U,F,act_s,mass,d,act_F,eigenvals);
+    f_loop.open("loops",ios::app);
+    if(f_loop.bad()){
+      cerr << "failed to open loops file" << "\n";exit(1);}
 
-        
+    f_loop2.open("loops2",ios::app);
+    if(f_loop2.bad()){
+      cerr << "failed to open loops2 file" << "\n";exit(1);}
+
+    f_det.open("det",ios::app);
+    if(f_det.bad()){cerr << "failed to open det file" << "\n";exit(1);}
+
+    f_kon1.open("kon1",ios::app);
+    if(f_kon1.bad()){cerr << "failed to open kon1 file" << "\n";exit(1);}
+
+    f_kon2.open("kon2",ios::app);
+    if(f_kon2.bad()){cerr << "failed to open kon2 file" << "\n";exit(1);}
+
+    first_time=0;
+  }
+
+  unit(U,U2);     // Polar-decomposition employed for holographic tests //
+
+  // check Bianchi
+  if(NUMLINK==5) {
+    B=Bianchi(U);
+    cout << "Bianchi is " << Tr(B*Adj(B)).real() << flush << "\n";
+  }
+
+  f_line  << line(U2,D-1) << "\n" << flush;      // Polyakov line along time //
+  f_line_z  << line(U2,D-2) << "\n" << flush;    // Polyakov line along z direction //
+
+  loop(U,wilson);
+  loop(U2,wilson2);
+  f_kon1 << konishi(U) << endl;
+  f_kon2 << konishi(U2)/16.0<< endl;
+
+  for(r=1;r<=(LX/2);r++){
+    for(m=1;m<=(T/2);m++){
+      f_loop << r << "\t" << m <<  "\t" << wilson[r][m]/((D-1)*SITES) << "\t" << flush;}
+  }
+  f_loop  << "\n" << flush;
+
+
+  for(r=1;r<=(LX/2);r++){
+    for(m=1;m<=(T/2);m++){
+      f_loop2 << r << "\t" << m <<  "\t" << wilson2[r][m]/((D-1)*SITES) << "\t" << flush;}
+  }
+  f_loop2  << "\n" << flush;
+
+  obs(U,F,act_s,mass,d,act_F,eigenvals);
+
 #ifdef FULLMATRIX
-        if((num%(GAP)==0)&&(FERMIONS==1)){
-	full_fermion_op(U,M);
-       // eigenvalues(M);
-	(void)Pfaffian(M);
-}
+  cout << "num = " << num << "\n";
+  if (num % GAP == 0 && FERMIONS == 1) {
+    full_fermion_op(U, M);
+    Pfaffian(M);
+    // eigenvalues(M);
+  }
 #endif
 
-	f_data << act_s << "\t" << act_F << "\n" << flush;
-        f_det << d << endl;
-    
-        scalars(U,t1,t2);
-	
-        f_scalars << t1 << "\t" << t2 <<  "\n" << flush;
+  f_data << act_s << "\t" << act_F << "\n" << flush;
+  f_det << d << endl;
 
-        if(SMALLEIG==1){	
-	sites=0;
-	while(loop_over_lattice(x,sites)){
-	for(j=0;j<NUMLINK;j++){
-	for(k=0;k<NCOLOR;k++){
-        f_av << eigenvals[sites-1][j][k] << "\t" ;}
-	f_av << "\n";}}
-	f_av << flush;}
+  scalars(U,t1,t2);
 
-	return;
+  f_scalars << t1 << "\t" << t2 <<  "\n" << flush;
+
+  if(SMALLEIG==1){
+    sites=0;
+    while(loop_over_lattice(x,sites)){
+      for(j=0;j<NUMLINK;j++){
+        for(k=0;k<NCOLOR;k++){
+          f_av << eigenvals[sites-1][j][k] << "\t" ;}
+        f_av << "\n";}}
+    f_av << flush;}
+
+  return;
 }

--- a/measure.cpp
+++ b/measure.cpp
@@ -1,7 +1,7 @@
 #include "measure.h"
 
 void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num) {
-  static int first_time=1;
+  static int first_time = 1;
   static ofstream f_data,f_av,f_scalars;
   static ofstream f_line,f_kon1,f_kon2, f_line_z;
   static ofstream f_loop,f_loop2,f_det;
@@ -56,14 +56,14 @@ void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num) {
     f_kon2.open("kon2",ios::app);
     if(f_kon2.bad()){cerr << "failed to open kon2 file" << "\n";exit(1);}
 
-    first_time=0;
+    first_time = 0;
   }
 
   unit(U,U2);     // Polar-decomposition employed for holographic tests //
 
   // check Bianchi
-  if(NUMLINK==5) {
-    B=Bianchi(U);
+  if(NUMLINK == 5) {
+    B = Bianchi(U);
     cout << "Bianchi is " << Tr(B*Adj(B)).real() << flush << "\n";
   }
 
@@ -75,15 +75,15 @@ void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num) {
   f_kon1 << konishi(U) << endl;
   f_kon2 << konishi(U2)/16.0<< endl;
 
-  for(r=1;r<=(LX/2);r++){
-    for(m=1;m<=(T/2);m++){
+  for(r = 1;r<=(LX/2);r++){
+    for(m = 1;m<=(T/2);m++){
       f_loop << r << "\t" << m <<  "\t" << wilson[r][m]/((D-1)*SITES) << "\t" << flush;}
   }
   f_loop  << "\n" << flush;
 
 
-  for(r=1;r<=(LX/2);r++){
-    for(m=1;m<=(T/2);m++){
+  for(r = 1;r<=(LX/2);r++){
+    for(m = 1;m<=(T/2);m++){
       f_loop2 << r << "\t" << m <<  "\t" << wilson2[r][m]/((D-1)*SITES) << "\t" << flush;}
   }
   f_loop2  << "\n" << flush;
@@ -106,11 +106,11 @@ void measure(const Gauge_Field &U, const Twist_Fermion &F,int &num) {
 
   f_scalars << t1 << "\t" << t2 <<  "\n" << flush;
 
-  if(SMALLEIG==1){
-    sites=0;
+  if(SMALLEIG == 1){
+    sites = 0;
     while(loop_over_lattice(x,sites)){
-      for(j=0;j<NUMLINK;j++){
-        for(k=0;k<NCOLOR;k++){
+      for(j = 0;j<NUMLINK;j++){
+        for(k = 0;k<NCOLOR;k++){
           f_av << eigenvals[sites-1][j][k] << "\t" ;}
         f_av << "\n";}}
     f_av << flush;}

--- a/read_in.cpp
+++ b/read_in.cpp
@@ -1,66 +1,65 @@
 #include "read_in.h"
 
-void read_in(Gauge_Field &u, Twist_Fermion &F){
-ifstream f_read;
-int LDUM, TDUM;
-double BETADUM, NCOLORDUM, DTDUM;
-Afield dummy2;
-Umatrix dummy;
-Lattice_Vector x;
-int site,mu,nu;
-Site_Field s;
-Link_Field l;
-Plaq_Field p;
+void read_in(Gauge_Field &u, Twist_Fermion &F) {
+  ifstream f_read;
+  int LDUM, TDUM;
+  double BETADUM, NCOLORDUM, DTDUM;
+  Afield dummy2;
+  Umatrix dummy;
+  Lattice_Vector x;
+  int site,mu,nu;
+  Site_Field s;
+  Link_Field l;
+  Plaq_Field p;
 
-f_read.open("config");
-if(f_read.bad()){
-cout << "error opening config file to read\n" << flush;}
+  f_read.open("config");
+  if (f_read.bad()) {
+    cout << "error opening config file to read\n" << flush;}
 
-f_read >> LDUM >> TDUM >> BETADUM >> DTDUM >> NCOLORDUM; 
-if ((LDUM!=LX) || (TDUM!=T)) {cout << "Wrong size lattice read in - Abort\n";}
-cout << "config coupling is " << BETADUM << "\n";
-cout << "time step used for input config " << DTDUM << "\n" << flush;
-cout << "number of colors " << NCOLORDUM << "\n" << flush;
+  f_read >> LDUM >> TDUM >> BETADUM >> DTDUM >> NCOLORDUM;
+  if (LDUM != LX || TDUM != T)
+    cout << "Wrong size lattice read in - Abort\n";
+  cout << "config coupling is " << BETADUM << "\n";
+  cout << "time step used for input config " << DTDUM << "\n" << flush;
+  cout << "number of colors " << NCOLORDUM << "\n" << flush;
 
-site=0;
-while(loop_over_lattice(x,site)){
-for(int mu=0;mu<NUMLINK;mu++){
-f_read >> dummy;
-u.set(x,mu,dummy);}
-}
+  site=0;
+  while(loop_over_lattice(x,site)) {
+    for (int mu=0;mu<NUMLINK;mu++) {
+      f_read >> dummy;
+      u.set(x,mu,dummy);}
+  }
 
+  site=0;
+  while(loop_over_lattice(x,site)) {
+    f_read >> dummy2;
+    s.set(x,dummy2);
+  }
+  F.setS(s);
 
-site=0;
-while(loop_over_lattice(x,site)){
-f_read >> dummy2;
-s.set(x,dummy2);
-}
-F.setS(s);
+  site=0;
+  while(loop_over_lattice(x,site)) {
+    for (mu=0;mu<NUMLINK;mu++) {
+      f_read >> dummy2;
+      l.set(x,mu,dummy2);
+    }
+  }
+  F.setL(l);
 
+  site=0;
+  while(loop_over_lattice(x,site)) {
+    for (mu=0;mu<NUMLINK;mu++) {
+      p.set(x,mu,mu,Afield());
+      for (nu=mu+1;nu<NUMLINK;nu++) {
+        f_read >> dummy2;
+        p.set(x,mu,nu,dummy2);
+        p.set(x,nu,mu,-1.0*dummy2);
+      }
+    }
+  }
+  F.setC(p);
 
-site=0;
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){
-f_read >> dummy2;
-l.set(x,mu,dummy2);
-}
-}
-F.setL(l);
-
-site=0;
-while(loop_over_lattice(x,site)){
-for(mu=0;mu<NUMLINK;mu++){
-p.set(x,mu,mu,Afield());
-for(nu=mu+1;nu<NUMLINK;nu++){
-f_read >> dummy2;
-p.set(x,mu,nu,dummy2);
-p.set(x,nu,mu,-1.0*dummy2);
-}
-}
-}
-F.setC(p);
-
-f_read.close();
-return;
+  f_read.close();
+  return;
 }
 

--- a/read_param.cpp
+++ b/read_param.cpp
@@ -33,7 +33,7 @@ void read_param() {
   // BETA is Rt (BETA in units of root lambda)
   // GAMMA is MASS in units of root lambda
   LAMBDA = 1.0;
-  G = 0.0;
+  G = 0.0;    // !!!
   if (D == 4) {
     KAPPA = 0.5 * NCOLOR / LAMBDA;
 

--- a/read_param.cpp
+++ b/read_param.cpp
@@ -3,9 +3,7 @@
 #include <stdio.h>
 #include <sys/time.h>
 
-unsigned int random_seed()
-{
-
+unsigned int random_seed() {
  unsigned int seed;
  struct timeval tv;
  FILE *devrandom;
@@ -14,91 +12,90 @@ unsigned int random_seed()
    gettimeofday(&tv,0);
    seed = tv.tv_sec + tv.tv_usec;
    printf("Got seed %u from gettimeofday()\n",seed);
- } else {
+ }
+ else {
    fread(&seed,sizeof(seed),1,devrandom);
    printf("Got seed %u from /dev/random\n",seed);
    fclose(devrandom);
  }
-
- return(seed);
-
+ return seed;
 }
 
-void read_param(void){
-double LAMBDA,BETA,GAMMA;
-ifstream f_in("parameters");
-if(!f_in.good()){
-	cout << "\ncan't open file parameters to read data!\n";
-	exit(1);}
-f_in>>SWEEPS>>THERM>>GAP>>BETA>>GAMMA>>C1>>C2>>DT>>READIN >>SWEEPNO ;
+void read_param() {
+  double LAMBDA, BETA, GAMMA;
+  ifstream f_in("parameters");
+  if (!f_in.good()) {
+    cout << "\ncan't open file parameters to read data!\n";
+    exit(1);
+  }
+  f_in >> SWEEPS >> THERM >> GAP >> BETA >> GAMMA >> C1 >> C2 >> DT >> READIN >> SWEEPNO;
 
-// BETA is Rt (BETA in units of root lambda)
-// GAMMA  is MASS in units of root lambda
+  // BETA is Rt (BETA in units of root lambda)
+  // GAMMA is MASS in units of root lambda
+  LAMBDA = 1.0;
+  G = 0.0;
+  if (D == 4) {
+    KAPPA = 0.5 * NCOLOR / LAMBDA;
 
-LAMBDA=1.0;
-G=0.0;
+    if ((LX == 1)&&(LY == 1)&&(LZ == 1)&&(T!= 1))
+      KAPPA = KAPPA*(T*T*T)/(BETA*BETA*BETA);
 
-if(D==4){
-KAPPA=(NCOLOR*0.5)/LAMBDA;
+    if ((LX == 1)&&(LY == 1)&&(LZ!= 1)&&(T!= 1))
+      KAPPA = KAPPA*(T*T)/(BETA*BETA);
 
-if((LX==1)&&(LY==1)&&(LZ==1)&&(T!=1)){
-KAPPA=KAPPA*(T*T*T)/(BETA*BETA*BETA);}
+    if ((LX == 1)&&(LY!= 1)&&(LZ!= 1)&&(T!= 1))
+      KAPPA = KAPPA*T/BETA;
+  }
 
-if((LX==1)&&(LY==1)&&(LZ!=1)&&(T!=1)){
-KAPPA=KAPPA*(T*T)/(BETA*BETA);}
+  if (D == 2) {
+    KAPPA = (NCOLOR * 0.5 * T * T) / (LAMBDA * BETA * BETA);
 
-if((LX==1)&&(LY!=1)&&(LZ!=1)&&(T!=1)){
-KAPPA=KAPPA*T/BETA;}
+    if (LX == 1 && T != 1)
+      KAPPA = KAPPA * T / BETA;
+  }
 
-}
+  BMASS = GAMMA * BETA / T;
 
-if(D==2){
-KAPPA=(NCOLOR*0.5*T*T)/(LAMBDA*BETA*BETA);
+  TRAJECTORY_LENGTH = (int)(0.5/DT);
 
-if((LX==1)&&(T!=1)){
-KAPPA=KAPPA*T/BETA;}
+  if (FERMIONS == 1 && NUMLINK == 5)
+    cout << "16 supercharge theory\n";
+  if (FERMIONS == 1 && NUMLINK == 2)
+    cout << "4 supercharge theory\n";
+  if (FERMIONS == 0 && NUMLINK == 5)
+    cout << "Quenched 16 supercharge theory\n";
+  if (FERMIONS == 0 && NUMLINK == 2)
+    cout << "Quenched 4 supercharge theory\n";
 
-}
+  cout << "Number of colors " << NCOLOR <<  "\n";
+  cout << "Temporal extent " << T << "\n";
+  if (D == 2)
+    cout << "Spatial extent " << LX << "\n";
+  if (D == 4)
+    cout << "Spatial extent " << LX << "\t" << LY << "\t" << LZ << "\n";
 
-BMASS=GAMMA*BETA/T;
+  cout << "Inverse temperature in units of root lambda " << BETA << "\n";
+  cout << "Lattice Coupling " << KAPPA << "\n";
+  cout << "Mass in units of root lambda " << GAMMA << "\n";
+  cout << "Lattice scalar mass squared " << KAPPA*BMASS*BMASS << "\n";
+  cout << "C1 coeff " << C1 << "\n";
+  cout << "C2 coeff " << C2 << "\n";
+  cout << "Coupling to det " << G << "\n";
+  cout << "Thermalization sweeps " << THERM << "\n";
+  cout << "Number of sweeps " << SWEEPS << "\n";
+  cout << "Gap between measurements " << GAP << "\n";
+  cout << "Time step in leapfrog eqs " << DT << "\n";
+  cout << "Trajectory length " << TRAJECTORY_LENGTH << "\n";
+  cout << "Minimax approx degree " << DEGREE << "\n";
+  cout << "Reading initial config: (1 for yes, 0 for no) " << READIN << "\n";
 
-TRAJECTORY_LENGTH=(int)(0.5/DT);
+  if (PBC == 1.0)
+    cout << "periodic temporal bc for fermions" << "\n";
+  else
+    cout << "antiperiodic temporal bc for fermions" << "\n";
 
+  srand(random_seed());
+  setup();
 
-if((FERMIONS==1)&&(NUMLINK==5)){cout << "16 supercharge theory \n";}
-if((FERMIONS==1)&&(NUMLINK==2)){cout << "4 supercharge theory\n";}
-if((FERMIONS==0)&&(NUMLINK==5)){cout << "Quenched 16 supercharge theory \n";}
-if((FERMIONS==0)&&(NUMLINK==2)){cout << "Quenched 4 supercharge theory\n";}
-
-
-cout << "Number of colors " << NCOLOR <<  "\n";
-cout << "Temporal extent " << T << "\n";
-if(D==2){
-cout << "Spatial extent " << LX << "\n";}
-if(D==4){
-cout << "Spatial extent " << LX << "\t" << LY << "\t" << LZ << "\n";}
-
-cout << "Inverse temperature in units of root lambda " << BETA << "\n";
-cout << "Lattice Coupling " << KAPPA << "\n";
-cout << "Mass in units of root lambda " << GAMMA << "\n";
-cout << "Lattice scalar mass squared " << KAPPA*BMASS*BMASS << "\n";
-cout << "C1 coeff " << C1 << "\n";
-cout << "C2 coeff " << C2 << "\n";
-cout << "Coupling to det " << G << "\n";
-cout << "Thermalization sweeps " << THERM << "\n";
-cout << "Number of sweeps " << SWEEPS << "\n";
-cout << "Gap between measurements " << GAP << "\n";
-cout << "Time step in leapfrog eqs " << DT << "\n";
-cout << "Trajectory length " << TRAJECTORY_LENGTH << "\n";
-cout << "Minimax approx degree " << DEGREE << "\n";
-cout << "Reading initial config: (1 for yes, 0 for no) " << READIN << "\n";
-
-if (PBC==1.0) {cout << "periodic temporal bc for fermions" << "\n";}
-else{cout << "antiperiodic temporal bc for fermions" << "\n";}
-
-
-srand(random_seed());
-setup();
-
-return;
+  return;
 }

--- a/sym.cpp
+++ b/sym.cpp
@@ -3,6 +3,7 @@
 
 // This calls : update_o.cpp, measure.cpp, write_out.cpp //
 
+// Global variables
 int SWEEPS, GAP, THERM, SEED, READIN, OLDSWEEPNO;
 double KAPPA, DT, TIME, G;
 
@@ -21,14 +22,14 @@ int main(int argc, char *argv[]) {
   Twist_Fermion F;
 
 #ifdef GPU
-  int gpuid=atoi(argv[1]);
+  int gpuid = atoi(argv[1]);
   cudaSetDevice(gpuid);
   cout << "using GPU " << gpuid << endl;
 #endif
 
   read_param();            // READ PARAMETERS //
 
-  if(READIN)
+  if (READIN)
     read_in(U, F);
   else {
     U = Gauge_Field(0);        // IF READIN = 0  i.e not reading configs //
@@ -36,37 +37,37 @@ int main(int argc, char *argv[]) {
   }
 
   cout << "Warming up" << "\n" << flush;
-  DT=DT/10;
+  DT = DT/10;
   cout << "DT is " << DT << "\n" << flush;
-  for(sweep=1;sweep<=THERM/4;sweep++) {
-    clock_t time= clock();
+  for (sweep = 1;sweep<= THERM/4;sweep++) {
+    clock_t time = clock();
     update(U, F);
     cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
     write_out(U, F, 0);
   }
-  DT=DT*10;
+  DT = DT*10;
   cout << "DT is " << DT << "\n" << flush;
-  for(sweep=1;sweep<=(3*THERM)/4;sweep++) {
-    clock_t time=clock();
+  for (sweep = 1;sweep<=(3*THERM)/4;sweep++) {
+    clock_t time = clock();
     update(U, F);
     cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
     write_out(U, F, 0);
   }
 
   cout << "Commencing measurement sweeps" << "\n" << flush;
-
-  for(sweep=SWEEPNO+1;sweep<=SWEEPS;sweep++) {
-    clock_t time=clock();
+  for (sweep = SWEEPNO + 1; sweep <= SWEEPS; sweep++) {
+    clock_t time = clock();
     update(U, F);
     cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
 
     //  measure config
     cout << "sweep no. " << sweep << "\n" << flush;
 
-    if(sweep%GAP==0) {
+    if (sweep % GAP == 0) {
       measure(U, F, sweep);
-      //        write_out(U, F, sweep);
-      write_out(U, F, 0);}
+//      write_out(U, F, sweep);
+      write_out(U, F, 0);
+    }
   }
-  return(0);
+  return 0;
 }

--- a/sym.cpp
+++ b/sym.cpp
@@ -1,78 +1,72 @@
 #include "sym.h"
 
 
-// This calls : update_o.cpp, measure.cpp, write_out.cpp //  
+// This calls : update_o.cpp, measure.cpp, write_out.cpp //
 
-int SWEEPS,GAP,THERM,SEED,READIN,OLDSWEEPNO;
-double KAPPA,DT,TIME,G;
+int SWEEPS, GAP, THERM, SEED, READIN, OLDSWEEPNO;
+double KAPPA, DT, TIME, G;
 
-double amp[DEGREE],shift[DEGREE],ampdeg;
+double amp[DEGREE], shift[DEGREE], ampdeg;
 Umatrix Lambda[NUMGEN];
-double LARGECUT,SMALLCUT,BMASS,C2,MASS;
-int TRAJECTORY_LENGTH,TOTALNONZEROES;
+double LARGECUT, SMALLCUT, BMASS, C1, C2, MASS;
+int TRAJECTORY_LENGTH, TOTALNONZEROES;
 double perm[NUMLINK][NUMLINK][NUMLINK][NUMLINK][NUMLINK];
-int side[D],SIMULATING,SWEEPNO;
+int side[D], SIMULATING, SWEEPNO;
 int Lattice_Map[D];
-int num_in_row[LEN],BLOCK_MEASURE,BLOCKING;
+int num_in_row[LEN], BLOCK_MEASURE, BLOCKING;
 
-int main(int argc, char *argv[]){
-int sweep;
-Gauge_Field U,Up;
-Twist_Fermion F;
+int main(int argc, char *argv[]) {
+  int sweep;
+  Gauge_Field U, Up;
+  Twist_Fermion F;
 
 #ifdef GPU
-int gpuid=atoi(argv[1]);
-cudaSetDevice(gpuid);
-cout << "using GPU " << gpuid << endl;
+  int gpuid=atoi(argv[1]);
+  cudaSetDevice(gpuid);
+  cout << "using GPU " << gpuid << endl;
 #endif
 
-read_param();            // READ PARAMETERS // 
+  read_param();            // READ PARAMETERS //
 
-if(READIN){              
-read_in(U,F);
-}
-else{
-U=Gauge_Field(0);        // IF READIN = 0  i.e not reading configs // 
-F=Twist_Fermion(1);
-}
+  if(READIN)
+    read_in(U, F);
+  else {
+    U = Gauge_Field(0);        // IF READIN = 0  i.e not reading configs //
+    F = Twist_Fermion(1);
+  }
 
-cout << "Warming up" << "\n" << flush;
-DT=DT/10;
-cout << "DT is " << DT << "\n" << flush;
-for(sweep=1;sweep<=THERM/4;sweep++){
-clock_t time= clock();
-update(U,F);
-cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
-write_out(U,F,0);
-}
-DT=DT*10;
-cout << "DT is " << DT << "\n" << flush;
-for(sweep=1;sweep<=(3*THERM)/4;sweep++){
-clock_t time=clock();
-update(U,F);
-cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
-write_out(U,F,0);
-}
+  cout << "Warming up" << "\n" << flush;
+  DT=DT/10;
+  cout << "DT is " << DT << "\n" << flush;
+  for(sweep=1;sweep<=THERM/4;sweep++) {
+    clock_t time= clock();
+    update(U, F);
+    cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
+    write_out(U, F, 0);
+  }
+  DT=DT*10;
+  cout << "DT is " << DT << "\n" << flush;
+  for(sweep=1;sweep<=(3*THERM)/4;sweep++) {
+    clock_t time=clock();
+    update(U, F);
+    cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
+    write_out(U, F, 0);
+  }
 
-cout << "Commencing measurement sweeps" << "\n" << flush;
+  cout << "Commencing measurement sweeps" << "\n" << flush;
 
+  for(sweep=SWEEPNO+1;sweep<=SWEEPS;sweep++) {
+    clock_t time=clock();
+    update(U, F);
+    cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
 
-for(sweep=SWEEPNO+1;sweep<=SWEEPS;sweep++){
-clock_t time=clock();
-update(U,F);
-cout << "sweep time is " << float(clock()-time)/CLOCKS_PER_SEC << endl;
-	
-	//  measure config
-        cout << "sweep no. " << sweep << "\n" << flush;
+    //  measure config
+    cout << "sweep no. " << sweep << "\n" << flush;
 
-	if(sweep%GAP==0){
-        measure(U,F,sweep);
-//        write_out(U,F,sweep);
-        write_out(U,F,0);}
-        
-
-}
-return(0);
-
-
+    if(sweep%GAP==0) {
+      measure(U, F, sweep);
+      //        write_out(U, F, sweep);
+      write_out(U, F, 0);}
+  }
+  return(0);
 }

--- a/utilities.cpp
+++ b/utilities.cpp
@@ -9,150 +9,150 @@ double Complex::norm(void){return(sqrt(re*re+im*im));}
 void Complex::print(void) const {cout << "("<< re << ", " << im << ")";}
 
 ostream& operator<<(ostream& out,Complex c){
-	out<<c.real()<<"\t"<<c.imag();
-	return out;}
+  out<<c.real()<<"\t"<<c.imag();
+  return out;}
 istream& operator>>(istream& in,Complex & c){
-	double x,y;
-	in>>x>>y;
-	c=Complex(x,y);
-	return in;}
-	
+  double x,y;
+  in>>x>>y;
+  c=Complex(x,y);
+  return in;}
+
 
 Complex operator /(const Complex &o1, const Complex &o2){
-	Complex dum;
-	double norm;
-	norm=o2.real()*o2.real()+o2.imag()*o2.imag();
-	dum=Complex((o1.real()*o2.real()+o1.imag()*o2.imag())/norm,
-		(o1.imag()*o2.real()-o1.real()*o2.imag())/norm);
-	return(dum);}
+  Complex dum;
+  double norm;
+  norm=o2.real()*o2.real()+o2.imag()*o2.imag();
+  dum=Complex((o1.real()*o2.real()+o1.imag()*o2.imag())/norm,
+    (o1.imag()*o2.real()-o1.real()*o2.imag())/norm);
+  return(dum);}
 Complex pow(const Complex &o1, const int o2){
-	Complex c(1,0);
-	for (int i=0;i<o2;i++) c=c*o1;
-	return c;}
-  	 
-  
+  Complex c(1,0);
+  for (int i=0;i<o2;i++) c=c*o1;
+  return c;}
+
+
 
 // unitary matrix type Umatrix
 Umatrix::Umatrix(void){
-	for(int i=0;i<NCOLOR;i++){
-		for(int j=0;j<NCOLOR;j++) {mat[i][j]=Complex();}}
-	}
-	
+  for(int i=0;i<NCOLOR;i++){
+    for(int j=0;j<NCOLOR;j++) {mat[i][j]=Complex();}}
+  }
+
 Umatrix::Umatrix(int k){
          if(k==1){
          for(int i=0;i<NCOLOR;i++){
-	        for(int j=0;j<NCOLOR;j++) {mat[i][j]=Complex();}
-		}
-	 for(int n=0;n<NCOLOR;n++){
-	 mat[n][n]=Complex(1.0,0.0);}
-	 }
-	 else {cout << "wrong Umatrix constructor\n" << flush; }
-	 
+          for(int j=0;j<NCOLOR;j++) {mat[i][j]=Complex();}
+    }
+   for(int n=0;n<NCOLOR;n++){
+   mat[n][n]=Complex(1.0,0.0);}
+   }
+   else {cout << "wrong Umatrix constructor\n" << flush; }
+
 }
 
 Umatrix::Umatrix(Complex m[NCOLOR][NCOLOR]){
-	for(int i=0;i<NCOLOR;i++)
-		for(int j=0;j<NCOLOR;j++) mat[i][j]=m[i][j];}
-		
+  for(int i=0;i<NCOLOR;i++)
+    for(int j=0;j<NCOLOR;j++) mat[i][j]=m[i][j];}
+
 
 Complex Umatrix::get(int i, int j) const {return(mat[i][j]);}
 void Umatrix::set(int i, int j, const Complex o){mat[i][j]=o;}
 void Umatrix::print(void){
-	for(int i=0;i<NCOLOR;i++){
-		for(int j=0;j<NCOLOR;j++){mat[i][j].print();cout << "\t";}
-		cout << "\n";}
-		}
+  for(int i=0;i<NCOLOR;i++){
+    for(int j=0;j<NCOLOR;j++){mat[i][j].print();cout << "\t";}
+    cout << "\n";}
+    }
 Umatrix Adj(const Umatrix &u){
         Umatrix res;
         for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	res.set(i,j,conjug(u.get(j,i)));}
-	return(res);}		
+  for(int j=0;j<NCOLOR;j++){
+  res.set(i,j,conjug(u.get(j,i)));}
+  return(res);}
 
 
 Umatrix Trans(const Umatrix &u){
         Umatrix res;
         for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	res.set(i,j,u.get(j,i));}
-	return(res);}
-	
-			
+  for(int j=0;j<NCOLOR;j++){
+  res.set(i,j,u.get(j,i));}
+  return(res);}
+
+
 ostream& operator<<(ostream& out,Umatrix s){
 for(int i=0;i<NCOLOR;i++)
 for(int j=0;j<NCOLOR;j++){
-	out<<s.get(i,j)<<'\t';}
-	return out;}		
+  out<<s.get(i,j)<<'\t';}
+  return out;}
 istream& operator>>(istream& in, Umatrix & s){
-	Complex v[NCOLOR][NCOLOR];
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	in>>v[i][j];}
-	s=Umatrix(v);
-	return in;
-	 }	
-		
+  Complex v[NCOLOR][NCOLOR];
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++){
+  in>>v[i][j];}
+  s=Umatrix(v);
+  return in;
+   }
+
 
 Umatrix operator *(const Umatrix &o1, const Umatrix &o2){
          Umatrix r;
-	 Complex dum;
-	 for(int i=0;i<NCOLOR;i++)
-	 for(int j=0;j<NCOLOR;j++){
-	 dum=Complex();
-	 for(int k=0;k<NCOLOR;k++){
-	 dum=dum+o1.get(i,k)*o2.get(k,j);}
-	 r.set(i,j,dum);}
-	 return(r);}	 
-	 
+   Complex dum;
+   for(int i=0;i<NCOLOR;i++)
+   for(int j=0;j<NCOLOR;j++){
+   dum=Complex();
+   for(int k=0;k<NCOLOR;k++){
+   dum=dum+o1.get(i,k)*o2.get(k,j);}
+   r.set(i,j,dum);}
+   return(r);}
+
         Umatrix operator *(const Umatrix &o1, const Complex &o2){
         Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	dum.set(i,j,o1.get(i,j)*o2);}
-	return(dum);}
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++){
+  dum.set(i,j,o1.get(i,j)*o2);}
+  return(dum);}
         Umatrix operator *(const Complex &o2, const Umatrix &o1){
-	Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	dum.set(i,j,o1.get(i,j)*o2);}
-	return(dum);}
-	Umatrix operator *(const Umatrix &o1, const double o2){
+  Umatrix dum;
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++){
+  dum.set(i,j,o1.get(i,j)*o2);}
+  return(dum);}
+  Umatrix operator *(const Umatrix &o1, const double o2){
         Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	dum.set(i,j,o1.get(i,j)*o2);}
-	return(dum);}
-	Umatrix operator *(const double o2, const Umatrix &o1){
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++){
+  dum.set(i,j,o1.get(i,j)*o2);}
+  return(dum);}
+  Umatrix operator *(const double o2, const Umatrix &o1){
         Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++){
-	dum.set(i,j,o1.get(i,j)*o2);}
-	return(dum);}
-	Umatrix operator +(const Umatrix &x, const Umatrix &y){
-	Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++)
-	dum.set(i,j,x.get(i,j)+y.get(i,j));
-	return(dum);
-	}
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++){
+  dum.set(i,j,o1.get(i,j)*o2);}
+  return(dum);}
+  Umatrix operator +(const Umatrix &x, const Umatrix &y){
+  Umatrix dum;
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++)
+  dum.set(i,j,x.get(i,j)+y.get(i,j));
+  return(dum);
+  }
         Umatrix operator -(const Umatrix &x, const Umatrix &y){
-	Umatrix dum;
-	for(int i=0;i<NCOLOR;i++)
-	for(int j=0;j<NCOLOR;j++)
-	dum.set(i,j,x.get(i,j)-y.get(i,j));
-	return(dum);
-	}
-	
+  Umatrix dum;
+  for(int i=0;i<NCOLOR;i++)
+  for(int j=0;j<NCOLOR;j++)
+  dum.set(i,j,x.get(i,j)-y.get(i,j));
+  return(dum);
+  }
+
 
     Umatrix exp(const Umatrix &u){
-	Umatrix c,del,prod;
-	double fac=1.0;
+  Umatrix c,del,prod;
+  double fac=1.0;
         int i=1;
         prod=Umatrix(1);
         c=Umatrix(1);
         static int sum=0,counter=0;
-	
-	do{
+
+  do{
         fac=fac*(double)i;
         prod=prod*u;
         del=prod*(1.0/fac);
@@ -163,35 +163,35 @@ Umatrix operator *(const Umatrix &o1, const Umatrix &o2){
         sum+=i;
         counter++;
         if(counter==100000){
-        cout << "mean no. of terms in exp() " 
+        cout << "mean no. of terms in exp() "
         << (double)sum/counter << "\n" << flush;
         counter=0;sum=0;}
-        
-	return(c);}
-	 
-					
-	
+
+  return(c);}
+
+
+
 Complex Tr(const Umatrix &o){
          Complex dum=Complex();
-	 for(int i=0;i<NCOLOR;i++)
-	 dum=dum+o.get(i,i);
-	 return(dum);}	 
+   for(int i=0;i<NCOLOR;i++)
+   dum=dum+o.get(i,i);
+   return(dum);}
 
 Umatrix gaussU(void){
-	int i;
-	Umatrix tmp=Umatrix();
-	for(i=0;i<NUMGEN;i++){
-	tmp=tmp+1.0/sqrt(2.0)*Complex(gasdev(),gasdev())*Lambda[i];}
-	return(tmp);
-	}
+  int i;
+  Umatrix tmp=Umatrix();
+  for(i=0;i<NUMGEN;i++){
+  tmp=tmp+1.0/sqrt(2.0)*Complex(gasdev(),gasdev())*Lambda[i];}
+  return(tmp);
+  }
 
 
 // adjoint field matrix type Afield
 Afield::Afield(void){
-	for(int i=0;i<NUMGEN;i++)
-		{afield[i]=Complex();}
-	}
-	
+  for(int i=0;i<NUMGEN;i++)
+    {afield[i]=Complex();}
+  }
+
 Afield::Afield(int c){
 if(c==1){
 for(int i=0;i<NUMGEN;i++){
@@ -202,9 +202,9 @@ return;
 }
 
 Afield::Afield(Complex m[NUMGEN]){
-	for(int i=0;i<NUMGEN;i++)
-		afield[i]=m[i];}
-				
+  for(int i=0;i<NUMGEN;i++)
+    afield[i]=m[i];}
+
 Afield gaussA(void){
 Afield dum=Afield();
 
@@ -218,71 +218,71 @@ return(dum);
 Complex Afield::get(int i) const {return(afield[i]);}
 void Afield::set(int i, const Complex o){afield[i]=o;}
 void Afield::print(void){
-	for(int i=0;i<NUMGEN;i++){
-		afield[i].print();cout << "\t";}
-		cout << "\n";
-		}
+  for(int i=0;i<NUMGEN;i++){
+    afield[i].print();cout << "\t";}
+    cout << "\n";
+    }
 
-// nb using antihermitian basis for Lambdas		
+// nb using antihermitian basis for Lambdas
 Afield Cjg(const Afield &u){
         Afield res;
         for(int i=0;i<NUMGEN;i++){
-	res.set(i,conjug(u.get(i)));}
-	return(res);}		
-		
+  res.set(i,conjug(u.get(i)));}
+  return(res);}
+
 ostream& operator<<(ostream& out,Afield s){
 for(int i=0;i<NUMGEN;i++)
 {
-	out<<s.get(i)<<'\t';}
-	return out;}
-			
+  out<<s.get(i)<<'\t';}
+  return out;}
+
 istream& operator>>(istream& in, Afield & s){
-	Complex v[NUMGEN];
-	for(int j=0;j<NUMGEN;j++){
-	in>>v[j];}
-	s=Afield(v);
-	return in;
-	}		
-	 
-	 
+  Complex v[NUMGEN];
+  for(int j=0;j<NUMGEN;j++){
+  in>>v[j];}
+  s=Afield(v);
+  return in;
+  }
+
+
         Afield operator *(const Afield &o1, const Complex &o2){
         Afield dum;
-	for(int i=0;i<NUMGEN;i++)
-	{
-	dum.set(i,o1.get(i)*o2);}
-	return(dum);}
+  for(int i=0;i<NUMGEN;i++)
+  {
+  dum.set(i,o1.get(i)*o2);}
+  return(dum);}
         Afield operator *(const Complex &o2, const Afield &o1){
-	Afield dum;
-	for(int i=0;i<NUMGEN;i++)
-	{
-	dum.set(i,o1.get(i)*o2);}
-	return(dum);}
-	Afield operator *(const Afield &o1, const double o2){
+  Afield dum;
+  for(int i=0;i<NUMGEN;i++)
+  {
+  dum.set(i,o1.get(i)*o2);}
+  return(dum);}
+  Afield operator *(const Afield &o1, const double o2){
         Afield dum;
-	for(int i=0;i<NUMGEN;i++)
-	{
-	dum.set(i,o1.get(i)*o2);}
-	return(dum);}
-	Afield operator *(const double o2, const Afield &o1){
+  for(int i=0;i<NUMGEN;i++)
+  {
+  dum.set(i,o1.get(i)*o2);}
+  return(dum);}
+  Afield operator *(const double o2, const Afield &o1){
         Afield dum;
-	for(int i=0;i<NUMGEN;i++)
-	{
-	dum.set(i,o1.get(i)*o2);}
-	return(dum);}
-	Afield operator +(const Afield &x, const Afield &y){
-	Afield dum;
-	for(int i=0;i<NUMGEN;i++){
-	dum.set(i,x.get(i)+y.get(i));}
-	return(dum);
-	}
+  for(int i=0;i<NUMGEN;i++)
+  {
+  dum.set(i,o1.get(i)*o2);}
+  return(dum);}
+  Afield operator +(const Afield &x, const Afield &y){
+  Afield dum;
+  for(int i=0;i<NUMGEN;i++){
+  dum.set(i,x.get(i)+y.get(i));}
+  return(dum);
+  }
         Afield operator -(const Afield &x, const Afield &y){
-	Afield dum;
-	for(int i=0;i<NUMGEN;i++){
-	dum.set(i,x.get(i)-y.get(i));}
-	return(dum);
-	}
-	
- 
+  Afield dum;
+  for(int i=0;i<NUMGEN;i++){
+  dum.set(i,x.get(i)-y.get(i));}
+  return(dum);
+  }
+
+
 
  Complex operator *(const Afield &A, const Afield &B){
  Complex dum=Complex();
@@ -290,8 +290,8 @@ istream& operator>>(istream& in, Afield & s){
  dum=dum+A.get(i)*B.get(i);}
  return(dum);
  }
- 
- 				
+
+
 Lattice_Vector::Lattice_Vector(void){for(int i=0;i<D;i++)coords[i]=0;}
 Lattice_Vector::Lattice_Vector(int mu){
 if(mu<D){
@@ -370,7 +370,7 @@ if(x.get(D-1)+y.get(D-1)>(T-1))return(PBC);
 return(1.0);
 }
 
-double BC(const Lattice_Vector &x, const Lattice_Vector &y, 
+double BC(const Lattice_Vector &x, const Lattice_Vector &y,
 const Lattice_Vector &z){
 
 if(x.get(D-1)+y.get(D-1)+z.get(D-1)<0) return(PBC);
@@ -379,7 +379,7 @@ if(x.get(D-1)+y.get(D-1)+z.get(D-1)>(T-1))return(PBC);
 return(1.0);
 }
 
-double BC(const Lattice_Vector &x, const Lattice_Vector &y, 
+double BC(const Lattice_Vector &x, const Lattice_Vector &y,
 const Lattice_Vector &z, const Lattice_Vector &w){
 
 if(x.get(D-1)+y.get(D-1)+z.get(D-1)+w.get(D-1)<0) return(PBC);
@@ -474,7 +474,7 @@ link[site][mu]=u;
 return;
 }
 
-	 
+
 Gauge_Field Adj(const Gauge_Field & U){
 int site;
 Gauge_Field W;
@@ -712,6 +712,22 @@ dum.set(x,j,k,s1.get(x,j,k)-s2.get(x,j,k));
 return(dum);
 }
 
+UPlaq_Field Plaq(const Gauge_Field &U){
+Lattice_Vector x,e_mu,e_nu;
+int site=0,mu,nu;
+UPlaq_Field P;
+
+while(loop_over_lattice(x,site)){
+for(mu=0;mu<NUMLINK;mu++){
+for(nu=mu+1;nu<NUMLINK;nu++){
+e_mu=Lattice_Vector(mu);
+e_nu=Lattice_Vector(nu);
+P.set(x,mu,nu,
+U.get(x,mu)*U.get(x+e_mu,nu)*Adj(U.get(x+e_nu,mu))*Adj(U.get(x,nu)));
+P.set(x,nu,mu,Adj(P.get(x,mu,nu)));
+}}}
+return(P);
+}
 
 UPlaq_Field operator *(const double o, const UPlaq_Field &s){
 int sites=0;
@@ -1062,7 +1078,7 @@ site=site+x.get(i)*Lattice_Map[i];
 return(square[site][mu][nu]);
 }
 
-void Plaq_Field::set(const Lattice_Vector &x, const int mu, const int nu, 
+void Plaq_Field::set(const Lattice_Vector &x, const int mu, const int nu,
 const Afield &u){
 int site=0,i;
 
@@ -1296,26 +1312,26 @@ return;
 ostream& operator<<(ostream& out, Adjoint_Matrix s){
 for(int i=0;i<NUMGEN;i++){
 for(int j=0;j<NUMGEN;j++){
-	out<<s.get(i,j)<<'\t';}}
-	return out;}
-			
-istream& operator>>(istream& in, Adjoint_Matrix & s){
-	Complex v[NUMGEN][NUMGEN];
-	for(int j=0;j<NUMGEN;j++){
-	for(int i=0;i<NUMGEN;i++){
-	in>>v[j][i];}}
-	s=Adjoint_Matrix(v);
-	return in;
-	}	
+  out<<s.get(i,j)<<'\t';}}
+  return out;}
 
-	
+istream& operator>>(istream& in, Adjoint_Matrix & s){
+  Complex v[NUMGEN][NUMGEN];
+  for(int j=0;j<NUMGEN;j++){
+  for(int i=0;i<NUMGEN;i++){
+  in>>v[j][i];}}
+  s=Adjoint_Matrix(v);
+  return in;
+  }
+
+
 Adjoint_Links::Adjoint_Links(void){
 for(int i=0;i<SITES;i++)
 for(int j=0;j<NUMLINK;j++){
 alinks[i][j]=Adjoint_Matrix();
 }
 return;
-} 
+}
 
 Adjoint_Matrix Adjoint_Links::get(const Lattice_Vector &x, const int mu) const{
 int site=0,i;
@@ -1460,7 +1476,7 @@ swap=0;
 for(p=0;p<4;p++){
 if(seq[p]>seq[p+1]) {tmp=seq[p];seq[p]=seq[p+1];seq[p+1]=tmp;
                      swap++;permutation*=(-1.0);}
-		    }
+        }
 }
 while(swap>0);
 return(permutation);
@@ -1655,104 +1671,98 @@ return(dum);
 
 
 Twist_Fermion betaterm(const Adjoint_Links &V, const Twist_Fermion &F){
-int a,b,sites,mu;
-Lattice_Vector x;
-Twist_Fermion dum=Twist_Fermion();
-Site_Field s=Site_Field();
-Link_Field l=Link_Field();
-Complex tmp;
-Afield tmp2;
+  int a,b,sites,mu;
+  Lattice_Vector x;
+  Twist_Fermion dum=Twist_Fermion();
+  Site_Field s=Site_Field();
+  Link_Field l=Link_Field();
+  Complex tmp;
+  Afield tmp2;
 
-// only relevant if U(N)
+  // only relevant if U(N)
 
-if(NUMGEN==(NCOLOR*NCOLOR-1)){return(dum);}
-//SIMON: beta term modification
+  if(NUMGEN==(NCOLOR*NCOLOR-1)){return(dum);}
+  //SIMON: beta term modification
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-tmp2=Afield();
+  sites=0;
+  while(loop_over_lattice(x,sites)){
+    tmp2=Afield();
 
-for(mu=0;mu<NUMLINK;mu++){
+    for(mu=0;mu<NUMLINK;mu++){
 
-for(a=0;a<NUMGEN-1;a++){
-tmp=Complex();
-for(b=0;b<NUMGEN;b++){
-tmp=tmp+
-conjug(V.get(x,mu).get(a,b))*F.getL().get(x,mu).get(b);}
+      for(a=0;a<NUMGEN-1;a++){
+        tmp=Complex();
+        for(b=0;b<NUMGEN;b++){
+          tmp=tmp+
+            conjug(V.get(x,mu).get(a,b))*F.getL().get(x,mu).get(b);}
 
-tmp2.set(a,tmp);}
+        tmp2.set(a,tmp);}
 
-s.set(x,C1*0.5*tmp2);}
+      s.set(x,C1*0.5*tmp2);}
 
-dum.setS(s);
-}
+    dum.setS(s);
+  }
 
-sites=0;
-while(loop_over_lattice(x,sites)){
-for(mu=0;mu<NUMLINK;mu++){
+  sites=0;
+  while(loop_over_lattice(x,sites)){
+    for(mu=0;mu<NUMLINK;mu++){
+      tmp2=Afield();
+      for(b=0;b<NUMGEN;b++){
+        tmp=Complex();
+        for(a=0;a<NUMGEN-1;a++){
+          tmp=tmp+
+            conjug(V.get(x,mu).get(a,b))*F.getS().get(x).get(a);}
+        tmp2.set(b,tmp);
+      }
 
-tmp2=Afield();
-for(b=0;b<NUMGEN;b++){
-tmp=Complex();
-for(a=0;a<NUMGEN-1;a++){
-tmp=tmp+
-conjug(V.get(x,mu).get(a,b))*F.getS().get(x).get(a);}
-tmp2.set(b,tmp);
-}
-
-l.set(x,mu,-0.5*C1*tmp2);
-}
-}
-
-dum.setL(l);
-
-return(dum);
-
+      l.set(x,mu,-0.5*C1*tmp2);
+    }
+  }
+  dum.setL(l);
+  return dum;
 }
 
 
 Twist_Fermion Fermion_op(const Adjoint_Links &V, const Twist_Fermion &F){
-Twist_Fermion F2=Twist_Fermion(),F3;
+  Twist_Fermion F2=Twist_Fermion(),F3;
 
-F2.setC(Dplus(V,F.getL()));
-F2.setL(Dminus(V,F.getC()));
-F2.setL(F2.getL()+0.5*Dbplus(V,F.getS()));
-F2.setS(0.5*Dbminus(V,F.getL()));
+  F2.setC(Dplus(V,F.getL()));
+  F2.setL(Dminus(V,F.getC()));
+  F2.setL(F2.getL()+0.5*Dbplus(V,F.getS()));
+  F2.setS(0.5*Dbminus(V,F.getL()));
 
-F3=betaterm(V,F);
-F2.setS(F2.getS()+F3.getS());
-F2.setL(F2.getL()+F3.getL());
+  F3=betaterm(V,F);
+  F2.setS(F2.getS()+F3.getS());
+  F2.setL(F2.getL()+F3.getL());
 
-// Q-closed piece
-if(NUMLINK==5){
-F2.setC(F2.getC()+0.5*Dbminus(V,F.getC())+0.5*Dbplus(V,F.getC()));}
+  // Q-closed piece
+  if(NUMLINK==5){
+    F2.setC(F2.getC()+0.5*Dbminus(V,F.getC())+0.5*Dbplus(V,F.getC()));}
 
-
-return(F2);
-
+  return F2;
 }
 
 Twist_Fermion Adj_Fermion_op(const Adjoint_Links &V, const Twist_Fermion &F){
-Twist_Fermion F2=Twist_Fermion(),F3,F4;
+  Twist_Fermion F2=Twist_Fermion(),F3,F4;
 
-F3=Cjg(F);
+  F3=Cjg(F);
 
-F2.setC(Dplus(V,F3.getL()));
-F2.setL(Dminus(V,F3.getC()));
-F2.setL(F2.getL()+0.5*Dbplus(V,F3.getS()));
-F2.setS(0.5*Dbminus(V,F3.getL()));
+  F2.setC(Dplus(V,F3.getL()));
+  F2.setL(Dminus(V,F3.getC()));
+  F2.setL(F2.getL()+0.5*Dbplus(V,F3.getS()));
+  F2.setS(0.5*Dbminus(V,F3.getL()));
 
-F4=betaterm(V,F3);
-F2.setS(F2.getS()+F4.getS());
-F2.setL(F2.getL()+F4.getL());
+  F4=betaterm(V,F3);
+  F2.setS(F2.getS()+F4.getS());
+  F2.setL(F2.getL()+F4.getL());
 
-// Q-closed piece
-if(NUMLINK==5){
-F2.setC(F2.getC()+0.5*Dbminus(V,F3.getC())+0.5*Dbplus(V,F3.getC()));}
+  // Q-closed piece
+  if(NUMLINK==5){
+    F2.setC(F2.getC()+0.5*Dbminus(V,F3.getC())+0.5*Dbplus(V,F3.getC()));}
 
-F2=-1.0*Cjg(F2);
+  F2=-1.0*Cjg(F2);
 
-return(F2);
+  return F2;
 }
 
 
@@ -1873,23 +1883,23 @@ void ceigsrt(Complex d[], int n)
 }
 
 double gasdev(void){
-	static int iset=0;
-	static double gset;
-	double fac,rsq,v1,v2;
-	if(iset==0){
-		do{
-			v1=2.0*rand()/(double)RAND_MAX-1.0;
-			v2=2.0*rand()/(double)RAND_MAX-1.0;
-			rsq=v1*v1+v2*v2;}
-		while(rsq>=1.0 || rsq == 0.0);
-		fac=sqrt(-2.0*log(rsq)/rsq);
-		gset=v1*fac;
-		iset=1;
-		return(v2*fac);}
-	else {
-		iset=0;
-		return(gset);}}
-        
+  static int iset=0;
+  static double gset;
+  double fac,rsq,v1,v2;
+  if(iset==0){
+    do{
+      v1=2.0*rand()/(double)RAND_MAX-1.0;
+      v2=2.0*rand()/(double)RAND_MAX-1.0;
+      rsq=v1*v1+v2*v2;}
+    while(rsq>=1.0 || rsq == 0.0);
+    fac=sqrt(-2.0*log(rsq)/rsq);
+    gset=v1*fac;
+    iset=1;
+    return(v2*fac);}
+  else {
+    iset=0;
+    return(gset);}}
+
 //hardcoded for U(2) for now
 
 Complex det(const Umatrix &u){
@@ -1919,14 +1929,14 @@ Umatrix dum;
 
 void fourn(double data[],int nn[],int ndim,int isign)
 {
-	int i1,i2,i3,i2rev,i3rev,ip1,ip2,ip3,ifp1,ifp2;
-	int ibit,idim,k1,k2,n,nprev,nrem,ntot;
-	double tempi,tempr;
-	double theta,wi,wpi,wpr,wr,wtemp;
-    
-	ntot=1;
-	for (idim=1;idim<=ndim;idim++)
-		ntot *= nn[idim];
+  int i1,i2,i3,i2rev,i3rev,ip1,ip2,ip3,ifp1,ifp2;
+  int ibit,idim,k1,k2,n,nprev,nrem,ntot;
+  double tempi,tempr;
+  double theta,wi,wpi,wpr,wr,wtemp;
+
+  ntot=1;
+  for (idim=1;idim<=ndim;idim++)
+    ntot *= nn[idim];
         nprev=1;
         for (idim=ndim;idim>=1;idim--) {
             n=nn[idim];

--- a/utilities.h
+++ b/utilities.h
@@ -20,7 +20,7 @@ const int NCOLOR = 3;
 const int NUMGEN = (NCOLOR*NCOLOR);
 //const int NUMGEN = (NCOLOR*NCOLOR)-1;  // Forcing SU(N) theory
 
-#define GPU
+//#define GPU
 #define Q16
 
 // Q=16 parameters
@@ -31,7 +31,7 @@ const int LX = 1;
 const int LY = 1;
 const int LZ = 32;
 const int SITES = (LX*LY*LZ*T);
-const unsigned int LEN = (16*NUMGEN*SITES);       // This is the size of fermion matrix // 
+const unsigned int LEN = (16*NUMGEN*SITES);       // This is the size of fermion matrix //
 const int supercharges =16;
 #else
 // Q=4 parameters
@@ -47,7 +47,7 @@ const int supercharges = 4;
 
 //const int NONZEROES = LEN/SITES/2;
 const unsigned int NONZEROES = (NUMGEN*NUMLINK*2);
- 
+
 const double GAUGETOL = 0.00000000000001;
 const int DEGREE = 10;      // Number of terms in  Remez approximation
 const double NORM = (1.0/sqrt(4.0*D));
@@ -64,59 +64,59 @@ const double INT_LAMBDA_MID = 0.614;
 //#define FULLMATRIX
 
 
-extern double ampdeg,amp[DEGREE],shift[DEGREE];
-extern int num_in_row[LEN],SIMULATING,SWEEPNO,TOTALNONZEROES;
-extern double KAPPA,DT,ALPHA,G,BMASS,C2,MASS;
-extern int SWEEPS,GAP,THERM,READIN,SEED, TRAJECTORY_LENGTH,OLDSWEEPNO;
+extern double ampdeg, amp[DEGREE], shift[DEGREE];
+extern int num_in_row[LEN], SIMULATING, SWEEPNO, TOTALNONZEROES;
+extern double KAPPA, DT, ALPHA, G, BMASS, C1, C2, MASS;
+extern int SWEEPS, GAP, THERM, READIN, SEED, TRAJECTORY_LENGTH, OLDSWEEPNO;
 extern double SMALLCUT, LARGECUT;
 extern double TIME;
 extern double perm[NUMLINK][NUMLINK][NUMLINK][NUMLINK][NUMLINK];
 extern int Lattice_Map[D];
-extern int side[D], BLOCK_MEASURE,BLOCKING;
+extern int side[D], BLOCK_MEASURE, BLOCKING;
 
 class Complex{
-	private:
-		double re,im;
-	public:
-		Complex();
-		Complex(double, double);
-		double real(void) const;
-		double imag(void) const;
-		double norm(void);
-		void print(void) const;
-		friend ostream& operator<<(ostream&,Complex);
-		friend istream& operator>>(istream&,Complex &);};
+  private:
+    double re, im;
+  public:
+    Complex();
+    Complex(double, double);
+    double real(void) const;
+    double imag(void) const;
+    double norm(void);
+    void print(void) const;
+    friend ostream& operator<<(ostream&, Complex);
+    friend istream& operator>>(istream&, Complex &);};
 
 inline Complex conjug(const Complex &o1){return(Complex(o1.real(),-o1.imag()));}
 inline Complex operator +(const Complex &o1, const Complex &o2){
-	return(Complex(o1.real()+o2.real(),o1.imag()+o2.imag()));}
+  return(Complex(o1.real()+o2.real(), o1.imag()+o2.imag()));}
 inline Complex operator -(const Complex &o1, const Complex &o2){
-	return(Complex(o1.real()-o2.real(),o1.imag()-o2.imag()));}
+  return(Complex(o1.real()-o2.real(), o1.imag()-o2.imag()));}
 inline Complex operator *(const Complex &o1, const Complex &o2){
-	return(Complex(o1.real()*o2.real()-o1.imag()*o2.imag(),
-		o1.real()*o2.imag()+o1.imag()*o2.real()));}
+  return(Complex(o1.real()*o2.real()-o1.imag()*o2.imag(),
+    o1.real()*o2.imag()+o1.imag()*o2.real()));}
 inline Complex operator *(const Complex &o1, const double o2){
-	return(Complex(o1.real()*o2,o1.imag()*o2));}
+  return(Complex(o1.real()*o2, o1.imag()*o2));}
 inline Complex operator *(const double o1, const Complex &o2){
-	return(Complex(o2.real()*o1,o2.imag()*o1));}
+  return(Complex(o2.real()*o1, o2.imag()*o1));}
 
-	
+
 Complex operator /(const Complex &, const Complex &);
 Complex pow(const Complex &, const int);
 
 class Umatrix{
-	private:
-		Complex mat[NCOLOR][NCOLOR];
-	public:
-		Umatrix();
-		Umatrix(int);
-		Umatrix(Complex [NCOLOR][NCOLOR]);
-		Complex get(int,int) const;
-		void set(int,int,const Complex);
-		void print(void);
-		friend ostream& operator<<(ostream &, Umatrix);
-		friend istream& operator>>(istream &, Umatrix &);};
-		
+  private:
+    Complex mat[NCOLOR][NCOLOR];
+  public:
+    Umatrix();
+    Umatrix(int);
+    Umatrix(Complex [NCOLOR][NCOLOR]);
+    Complex get(int, int) const;
+    void set(int, int, const Complex);
+    void print(void);
+    friend ostream& operator<<(ostream &, Umatrix);
+    friend istream& operator>>(istream &, Umatrix &);};
+
 Umatrix operator +(const Umatrix &o1, const Umatrix &o2);
 Umatrix operator -(const Umatrix &o1, const Umatrix &o2);
 Umatrix operator *(const Umatrix &, const Umatrix &);
@@ -132,14 +132,14 @@ Umatrix Trans(const Umatrix &);
 
 class Lattice_Vector{
 private:
-	int coords[D];
+  int coords[D];
 public:
-	Lattice_Vector(void);
-	Lattice_Vector(int);
-	void set(int, int);
-	int get(int) const;
-	void print(void) const;
-	};
+  Lattice_Vector(void);
+  Lattice_Vector(int);
+  void set(int, int);
+  int get(int) const;
+  void print(void) const;
+  };
 
 Lattice_Vector operator +(const Lattice_Vector &x, const Lattice_Vector &y);
 Lattice_Vector operator -(const Lattice_Vector &x, const Lattice_Vector &y);
@@ -157,31 +157,31 @@ int length(const Lattice_Vector &x);
 
 class Gauge_Field{
 private:
-	Umatrix link[SITES][NUMLINK];
-	
+  Umatrix link[SITES][NUMLINK];
+
 public:
         Gauge_Field(void);
-	Gauge_Field(int);
-	Umatrix get(const Lattice_Vector &, const int) const;
-	void set(const Lattice_Vector &, const int, const Umatrix &);
-	};
-	
+  Gauge_Field(int);
+  Umatrix get(const Lattice_Vector &, const int) const;
+  void set(const Lattice_Vector &, const int, const Umatrix &);
+  };
+
 Gauge_Field Adj(const Gauge_Field &);
 Gauge_Field Transpose(const Gauge_Field &);
 
 class Afield{
-	private:
-		Complex afield[NUMGEN];
-	public:
-		Afield(void);
-		Afield(int);
-		Afield(Complex [NUMGEN]);
-		Complex get(int) const;
-		void set(int,const Complex);
-		void print(void);
-		friend ostream& operator<<(ostream &, Afield);
-		friend istream& operator>>(istream &, Afield &);};
-		
+  private:
+    Complex afield[NUMGEN];
+  public:
+    Afield(void);
+    Afield(int);
+    Afield(Complex [NUMGEN]);
+    Complex get(int) const;
+    void set(int, const Complex);
+    void print(void);
+    friend ostream& operator<<(ostream &, Afield);
+    friend istream& operator>>(istream &, Afield &);};
+
 Afield operator +(const Afield &o1, const Afield &o2);
 Afield operator -(const Afield &o1, const Afield &o2);
 Afield operator *(const Afield &, const Complex &);
@@ -194,12 +194,12 @@ Afield gaussA(void);
 
 class Scalar_Plaquette{
 private:
-	Complex data[SITES][NUMLINK][NUMLINK];
+  Complex data[SITES][NUMLINK][NUMLINK];
 public:
-	Scalar_Plaquette(void);
-   	Complex get(const Lattice_Vector &, const int, const int) const;
-	void set(const Lattice_Vector &, const int, const int, const Complex &);
-	};
+  Scalar_Plaquette(void);
+    Complex get(const Lattice_Vector &, const int, const int) const;
+  void set(const Lattice_Vector &, const int, const int, const Complex &);
+  };
 
 
 Scalar_Plaquette operator +(const Scalar_Plaquette &, const Scalar_Plaquette &);
@@ -211,16 +211,16 @@ Scalar_Plaquette mydiff2(const Scalar_Plaquette &, const Scalar_Plaquette &);
 
 class USite_Field{
 private:
-	Umatrix points[SITES];
+  Umatrix points[SITES];
 public:
-	USite_Field(void);
-	USite_Field(int);
-   	Umatrix get(const Lattice_Vector &) const;
-	void set(const Lattice_Vector &, const Umatrix &);
-	void print(void);
-	};
+  USite_Field(void);
+  USite_Field(int);
+    Umatrix get(const Lattice_Vector &) const;
+  void set(const Lattice_Vector &, const Umatrix &);
+  void print(void);
+  };
 
-USite_Field Adj(const USite_Field &);	
+USite_Field Adj(const USite_Field &);
 
 USite_Field operator +(const USite_Field &, const USite_Field &);
 USite_Field operator -(const USite_Field &, const USite_Field &);
@@ -230,14 +230,14 @@ Umatrix operator *(const USite_Field &, const USite_Field &);
 
 class UPlaq_Field{
 private:
-	Umatrix square[SITES][NUMLINK][NUMLINK];
+  Umatrix square[SITES][NUMLINK][NUMLINK];
 public:
-	UPlaq_Field(void);
-	UPlaq_Field(int);
-	Umatrix get(const Lattice_Vector &, const int, const int) const;
-	void set(const Lattice_Vector &, const int, const int,  const Umatrix &);
-	void print(void);
-	};
+  UPlaq_Field(void);
+  UPlaq_Field(int);
+  Umatrix get(const Lattice_Vector &, const int, const int) const;
+  void set(const Lattice_Vector &, const int, const int,  const Umatrix &);
+  void print(void);
+  };
 
 
 UPlaq_Field Adj(const UPlaq_Field &);
@@ -251,16 +251,16 @@ UPlaq_Field Plaq(const Gauge_Field &);
 
 class Site_Field{
 private:
-	Afield points[SITES];
+  Afield points[SITES];
 public:
-	Site_Field(void);
-	Site_Field(int);
-	Afield get(const Lattice_Vector &) const;
-	void set(const Lattice_Vector &, const Afield &);
-	void print(void);
-	};
+  Site_Field(void);
+  Site_Field(int);
+  Afield get(const Lattice_Vector &) const;
+  void set(const Lattice_Vector &, const Afield &);
+  void print(void);
+  };
 
-Site_Field Cjg(const Site_Field &);	
+Site_Field Cjg(const Site_Field &);
 
 Site_Field operator +(const Site_Field &, const Site_Field &);
 Site_Field operator -(const Site_Field &, const Site_Field &);
@@ -271,14 +271,14 @@ Complex operator *(const Site_Field &, const Site_Field &);
 
 class Link_Field{
 private:
-	Afield links[SITES][NUMLINK];
+  Afield links[SITES][NUMLINK];
 public:
-	Link_Field(void);
-	Link_Field(int);
-	Afield get(const Lattice_Vector &, const int) const;
-	void set(const Lattice_Vector &, const int, const Afield &);
-	void print(void);
-	};
+  Link_Field(void);
+  Link_Field(int);
+  Afield get(const Lattice_Vector &, const int) const;
+  void set(const Lattice_Vector &, const int, const Afield &);
+  void print(void);
+  };
 
 
 Link_Field Cjg(const Link_Field &);
@@ -292,14 +292,14 @@ Complex operator *(const Link_Field &, const Link_Field &);
 
 class Plaq_Field{
 private:
-	Afield square[SITES][NUMLINK][NUMLINK];
+  Afield square[SITES][NUMLINK][NUMLINK];
 public:
-	Plaq_Field(void);
-	Plaq_Field(int);
-	Afield get(const Lattice_Vector &, const int, const int) const;
-	void set(const Lattice_Vector &, const int, const int,  const Afield &);
-	void print(void);
-	};
+  Plaq_Field(void);
+  Plaq_Field(int);
+  Afield get(const Lattice_Vector &, const int, const int) const;
+  void set(const Lattice_Vector &, const int, const int,  const Afield &);
+  void print(void);
+  };
 
 
 Plaq_Field Cjg(const Plaq_Field &);
@@ -322,12 +322,11 @@ public:
        friend ostream& operator<<(ostream &, Adjoint_Matrix);
        friend istream& operator>>(istream &, Adjoint_Matrix &);
        };
-       
 
 class Adjoint_Links{
 private:
        Adjoint_Matrix alinks[SITES][NUMLINK];
-       
+
 public:
        Adjoint_Links(void);
        Adjoint_Matrix get(const Lattice_Vector &, const int) const;
@@ -346,21 +345,21 @@ Plaq_Field Dbplus(const Adjoint_Links &, const Plaq_Field &);
 
 class Twist_Fermion{
 private:
-	Site_Field S;
-	Link_Field L;
-	Plaq_Field C;
-	
+  Site_Field S;
+  Link_Field L;
+  Plaq_Field C;
+
 public:
-	Twist_Fermion(void);
-	Twist_Fermion(int);
-	const Site_Field& getS(void) const;
-	const Link_Field& getL(void) const;
-	const Plaq_Field& getC(void) const;
-	void setS(const Site_Field &);
-	void setL(const Link_Field &);
-	void setC(const Plaq_Field &);
-	void print(void);
-	};
+  Twist_Fermion(void);
+  Twist_Fermion(int);
+  const Site_Field& getS(void) const;
+  const Link_Field& getL(void) const;
+  const Plaq_Field& getC(void) const;
+  void setS(const Site_Field &);
+  void setL(const Link_Field &);
+  void setC(const Plaq_Field &);
+  void print(void);
+  };
 
 
 Twist_Fermion Cjg(const Twist_Fermion &);
@@ -371,7 +370,7 @@ Twist_Fermion operator *(const double, const Twist_Fermion &);
 Twist_Fermion operator *(const Complex &, const Twist_Fermion &);
 Complex operator *(const Twist_Fermion &, const Twist_Fermion &);
 
-Twist_Fermion Fermion_op(const Adjoint_Links &, const Gauge_Field &,const Twist_Fermion &);
+Twist_Fermion Fermion_op(const Adjoint_Links &, const Gauge_Field &, const Twist_Fermion &);
 Twist_Fermion Adj_Fermion_op(const Adjoint_Links &, const Gauge_Field &,
 const Twist_Fermion &);
 UPlaq_Field Field_Strength(const Gauge_Field &U);
@@ -380,7 +379,7 @@ UPlaq_Field Bianchi(const Gauge_Field &U);
 void eigsrt(double d[], int n);
 void ceigsrt(Complex d[], int n);
 void epsilon(void);
-	
+
 extern Umatrix Lambda[NUMGEN];
 
 double gasdev(void);

--- a/utilities.h
+++ b/utilities.h
@@ -46,7 +46,7 @@ const int supercharges = 4;
 #endif
 
 //const int NONZEROES = LEN/SITES/2;
-const unsigned int NONZEROES = (NUMGEN*NUMLINK*2);
+const unsigned int NONZEROES = (NUMGEN*NUMLINK*8);
 
 const double GAUGETOL = 0.00000000000001;
 const int DEGREE = 10;      // Number of terms in  Remez approximation

--- a/utilities.h
+++ b/utilities.h
@@ -15,8 +15,8 @@ using namespace std;
 #define FMASS 0.0
 
 const int FERMIONS = 1;
-const int T = 8;
-const int NCOLOR = 3;
+const int T = 2;
+const int NCOLOR = 2;
 const int NUMGEN = (NCOLOR*NCOLOR);
 //const int NUMGEN = (NCOLOR*NCOLOR)-1;  // Forcing SU(N) theory
 
@@ -27,11 +27,11 @@ const int NUMGEN = (NCOLOR*NCOLOR);
 #ifdef Q16
 const int D = 4;
 const int NUMLINK = 5;
-const int LX = 1;
-const int LY = 1;
-const int LZ = 32;
+const int LX = 2;
+const int LY = 2;
+const int LZ = 2;
 const int SITES = (LX*LY*LZ*T);
-const unsigned int LEN = (16*NUMGEN*SITES);       // This is the size of fermion matrix //
+const unsigned int LEN = (16*NUMGEN*SITES);       // This is the size of fermion matrix
 const int supercharges =16;
 #else
 // Q=4 parameters
@@ -62,7 +62,6 @@ const double INT_LAMBDA_CONT = 0.386;
 const double INT_LAMBDA_MID = 0.614;
 
 //#define FULLMATRIX
-
 
 extern double ampdeg, amp[DEGREE], shift[DEGREE];
 extern int num_in_row[LEN], SIMULATING, SWEEPNO, TOTALNONZEROES;
@@ -160,7 +159,7 @@ private:
   Umatrix link[SITES][NUMLINK];
 
 public:
-        Gauge_Field(void);
+  Gauge_Field(void);
   Gauge_Field(int);
   Umatrix get(const Lattice_Vector &, const int) const;
   void set(const Lattice_Vector &, const int, const Umatrix &);


### PR DESCRIPTION
I needed to make several changes in order to compile and run the pfaffian measurement, for example defining C1 and implementing a Plaq() routine (which I copied from a version of the code Simon shared with me in January 2015).  With these changes implemented I successfully reproduce the parallel pfaffian result for a fixed gauge configuration.

Note that some bug seems to remain: The action computed at the beginning and end of the RHMC trajectory is nan.  I haven't looked into this since it just leads to the trajectory being rejected, as desired to keep the gauge configuration fixed.